### PR TITLE
Make tests run only on PRs to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: []
+    branches: [main]
   
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request updates the Test workflow to only trigger if a pull request targets the `main` branch of the repository.

This change was made in preparation for changes to the GitHub Pages documentation publishing process.