### PR TITLE
BSONEncoder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,5 +43,11 @@ let package = Package(
         .testTarget(
             name: "BSONParseTests",
             dependencies: ["BSONParse"]),
+        .target(
+            name: "BSONEncodable",
+            dependencies: ["BSONCompose"]),
+        .testTarget(
+            name: "BSONEncodableTests",
+            dependencies: ["BSONEncodable", "BSONCompose"]),
     ]
 )

--- a/Sources/BSONEncodable/BSONEncoder.swift
+++ b/Sources/BSONEncodable/BSONEncoder.swift
@@ -6,11 +6,21 @@
 //
 
 /// Use `BSONEncoder` to encode `Encodable` values into fully-formed BSON documents.
+/// 
+/// - Note: 
+/// This encoder does not respect custom `ValueProtocol` implementations.
+/// To encode custom BSON values differently than their `Encodable` implementation,
+/// Use `ComposedDocument` or `ComposedArrayDocument`.
 public struct BSONEncoder {
     /// Initializes an encoder.
     public init() {}
 
     /// Encodes the provided value into a BSON document.
+    /// 
+    /// - Note: 
+    /// This encoder does not respect custom ``ValueProtocol`` implementations.
+    /// To encode custom BSON values differently than their `Encodable` implementation,
+    /// Use ``ComposedDocument`` or ``ComposedArrayDocument``.
     /// 
     /// - Throws: 
     /// Re-throws any errors thrown in the value's `encode(to:)` method.

--- a/Sources/BSONEncodable/BSONEncoder.swift
+++ b/Sources/BSONEncodable/BSONEncoder.swift
@@ -1,0 +1,27 @@
+//
+//  BSONEncoder.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+/// Use `BSONEncoder` to encode `Encodable` values into fully-formed BSON documents.
+public struct BSONEncoder {
+    /// Initializes an encoder.
+    public init() {}
+
+    /// Encodes the provided value into a BSON document.
+    /// 
+    /// - Throws: 
+    /// Re-throws any errors thrown in the value's `encode(to:)` method.
+    /// 
+    /// - Parameter value: an `Encodable` value
+    /// 
+    /// - Returns: 
+    /// The bytes of the resulting BSON document.
+    public func encode<T: Encodable>(_ value: T) throws -> [UInt8] {
+        let containerProvider = BSONEncodingContainerProvider(codingPath: [])
+        try value.encode(to: containerProvider)
+        return containerProvider.bsonBytes
+    }
+}

--- a/Sources/BSONEncodable/BSONEncodingContainerProvider.swift
+++ b/Sources/BSONEncodable/BSONEncodingContainerProvider.swift
@@ -1,0 +1,54 @@
+//
+//  BSONContainerProvider.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+import BSONCompose
+
+class BSONEncodingContainerProvider {
+    /// The container selected by the object to encode.
+    var container: ValueBox? = nil
+
+    /// The path the encoder took to this point.
+    let codingPath: [CodingKey]
+
+    /// The userInfo dictionary for this encoder.
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    /// Initializes a container with the provided coding path.
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+    }
+}
+
+extension BSONEncodingContainerProvider: ValueProtocol {
+    var bsonBytes: [UInt8] {
+        container!.bsonBytes
+    }
+
+    var bsonType: UInt8 {
+        container!.bsonType
+    }
+}
+
+extension BSONEncodingContainerProvider: Encoder {
+    func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: codingPath)
+        self.container = ValueBox(container)
+        return KeyedEncodingContainer(container)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = BSONUnkeyedEncodingContainer(codingPath: codingPath)
+        self.container = ValueBox(container)
+        return container
+    }
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        let container = BSONSingleValueEncodingContainer(codingPath: codingPath)
+        self.container = ValueBox(container)
+        return container
+    }
+}

--- a/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
@@ -123,8 +123,10 @@ extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
         codingPath.append(key)
     }
 
-    func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
-        fatalError("not implemented")
+    func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        try value.encode(to: encoder)
+        contents.append(key, encoder)
     }
 
     func nestedContainer<NestedKey: CodingKey>(
@@ -137,14 +139,20 @@ extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
     }
 
     func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        fatalError("not implemented")
+        let nestedContainer = BSONUnkeyedEncodingContainer(codingPath: codingPath)
+        contents.append(key, nestedContainer)
+        return nestedContainer
     }
 
     func superEncoder() -> Encoder {
-        fatalError("not implemented")
+        let superEncoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        contents.append(("super", ValueBox(superEncoder)))
+        return superEncoder
     }
 
     func superEncoder(forKey key: Key) -> Encoder {
-        fatalError("not implemented")
+        let superEncoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        contents.append(key, superEncoder)
+        return superEncoder
     }
 }

--- a/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
@@ -1,0 +1,139 @@
+//
+//  BSONKeyedEncodingContainer.swift
+//  BSONKeyedEncodingContainer
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+import BSONCompose
+
+struct BSONKeyedEncodingContainer<Key: CodingKey> {
+    /// The contents of this container.
+    var contents: [(String, ValueBox)] = []
+    
+    /// The path the encoder took to this point.
+    var codingPath: [CodingKey]
+}
+
+extension BSONKeyedEncodingContainer: ValueProtocol {
+    var bsonBytes: [UInt8] {
+        ComposedDocument {
+            ForEach(contents) { key, value in 
+                key => value
+            }
+        }
+        .bsonBytes
+    }
+
+    var bsonType: UInt8 {
+        3
+    }
+}
+
+extension Array where Element == (String, ValueBox) {
+    /// Appends the provided key-value pair to the container's storage.
+    fileprivate mutating func append<T: ValueProtocol, K: CodingKey>(_ key: K, _ value: T) {
+        self.append((key.stringValue, ValueBox(value)))
+    }
+}
+
+extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
+    mutating func encodeNil(forKey key: Key) throws {
+        contents.append(key, Int32?.none)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Bool, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: String, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Double, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Float, forKey key: Key) throws {
+        contents.append(key, Double(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Int, forKey key: Key) throws {
+        if MemoryLayout<Int>.size == 4 {
+            contents.append(key, Int32(value))
+        } else {
+            contents.append(key, Int64(value))
+        }
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Int8, forKey key: Key) throws {
+        contents.append(key, Int32(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Int16, forKey key: Key) throws {
+        contents.append(key, Int32(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Int32, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: Int64, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: UInt, forKey key: Key) throws {
+        contents.append(key, UInt64(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: UInt8, forKey key: Key) throws {
+        contents.append(key, UInt64(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: UInt16, forKey key: Key) throws {
+        contents.append(key, UInt64(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: UInt32, forKey key: Key) throws {
+        contents.append(key, UInt64(value))
+        codingPath.append(key)
+    }
+
+    mutating func encode(_ value: UInt64, forKey key: Key) throws {
+        contents.append(key, value)
+        codingPath.append(key)
+    }
+
+    mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        fatalError("not implemented")
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        fatalError("not implemented")
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        fatalError("not implemented")
+    }
+
+    mutating func superEncoder() -> Encoder {
+        fatalError("not implemented")
+    }
+
+    mutating func superEncoder(forKey key: Key) -> Encoder {
+        fatalError("not implemented")
+    }
+}

--- a/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
@@ -7,17 +7,23 @@
 
 import BSONCompose
 
-struct BSONKeyedEncodingContainer<Key: CodingKey> {
+class BSONKeyedEncodingContainer<Key: CodingKey> {
     /// The contents of this container.
     var contents: [(String, ValueBox)] = []
     
     /// The path the encoder took to this point.
     var codingPath: [CodingKey]
+
+    /// Initializes a container with the provided coding path record.
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+    }
 }
 
 extension BSONKeyedEncodingContainer: ValueProtocol {
     var bsonBytes: [UInt8] {
-        ComposedDocument {
+        let contents = self.contents
+        return ComposedDocument {
             ForEach(contents) { key, value in 
                 key => value
             }
@@ -38,32 +44,32 @@ extension Array where Element == (String, ValueBox) {
 }
 
 extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
-    mutating func encodeNil(forKey key: Key) throws {
+    func encodeNil(forKey key: Key) throws {
         contents.append(key, Int32?.none)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Bool, forKey key: Key) throws {
+    func encode(_ value: Bool, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: String, forKey key: Key) throws {
+    func encode(_ value: String, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Double, forKey key: Key) throws {
+    func encode(_ value: Double, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Float, forKey key: Key) throws {
+    func encode(_ value: Float, forKey key: Key) throws {
         contents.append(key, Double(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Int, forKey key: Key) throws {
+    func encode(_ value: Int, forKey key: Key) throws {
         if MemoryLayout<Int>.size == 4 {
             contents.append(key, Int32(value))
         } else {
@@ -72,68 +78,73 @@ extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Int8, forKey key: Key) throws {
+    func encode(_ value: Int8, forKey key: Key) throws {
         contents.append(key, Int32(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Int16, forKey key: Key) throws {
+    func encode(_ value: Int16, forKey key: Key) throws {
         contents.append(key, Int32(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Int32, forKey key: Key) throws {
+    func encode(_ value: Int32, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: Int64, forKey key: Key) throws {
+    func encode(_ value: Int64, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: UInt, forKey key: Key) throws {
+    func encode(_ value: UInt, forKey key: Key) throws {
         contents.append(key, UInt64(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: UInt8, forKey key: Key) throws {
+    func encode(_ value: UInt8, forKey key: Key) throws {
         contents.append(key, UInt64(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: UInt16, forKey key: Key) throws {
+    func encode(_ value: UInt16, forKey key: Key) throws {
         contents.append(key, UInt64(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: UInt32, forKey key: Key) throws {
+    func encode(_ value: UInt32, forKey key: Key) throws {
         contents.append(key, UInt64(value))
         codingPath.append(key)
     }
 
-    mutating func encode(_ value: UInt64, forKey key: Key) throws {
+    func encode(_ value: UInt64, forKey key: Key) throws {
         contents.append(key, value)
         codingPath.append(key)
     }
 
-    mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+    func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
         fatalError("not implemented")
     }
 
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+    func nestedContainer<NestedKey: CodingKey>(
+        keyedBy keyType: NestedKey.Type, 
+        forKey key: Key
+    ) -> KeyedEncodingContainer<NestedKey> {
+        let nestedContainer = BSONKeyedEncodingContainer<NestedKey>(codingPath: codingPath)
+        contents.append(key, nestedContainer)
+        return KeyedEncodingContainer(nestedContainer)
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         fatalError("not implemented")
     }
 
-    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+    func superEncoder() -> Encoder {
         fatalError("not implemented")
     }
 
-    mutating func superEncoder() -> Encoder {
-        fatalError("not implemented")
-    }
-
-    mutating func superEncoder(forKey key: Key) -> Encoder {
+    func superEncoder(forKey key: Key) -> Encoder {
         fatalError("not implemented")
     }
 }

--- a/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
@@ -1,0 +1,125 @@
+//
+//  BSONSingleValueEncodingContainer.swift
+//
+//
+//  Created by Christopher Richez on March 28 2022
+//
+
+import BSONCompose
+
+struct BSONSingleValueEncodingContainer {
+    /// The value assigned to this container.
+    var encodedValue: [UInt8]? = nil
+
+    /// The type byte declared by the value assigned to this container.
+    var encodedType: UInt8? = nil
+
+    /// The path the encoder took to get to this point, used for error composition.
+    var codingPath: [CodingKey]
+}
+
+extension BSONSingleValueEncodingContainer: ValueProtocol {
+    var bsonBytes: [UInt8] {
+        encodedValue!
+    }
+
+    var bsonType: UInt8 {
+        encodedType!
+    }
+}
+
+extension BSONSingleValueEncodingContainer: SingleValueEncodingContainer {
+    mutating func encodeNil() throws {
+        encodedValue = []
+        encodedType = 10
+    }
+
+    mutating func encode(_ value: Bool) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: String) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: Double) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: Int32) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: UInt64) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: Int64) throws {
+        encodedValue = value.bsonBytes
+        encodedType = value.bsonType
+    }
+
+    mutating func encode(_ value: Float) throws {
+        let convertedValue = Double(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: Int) throws {
+        if MemoryLayout<Int>.size == 4 {
+            let convertedValue = Int32(value)
+            encodedValue = convertedValue.bsonBytes
+            encodedType = convertedValue.bsonType
+        } else {
+            let convertedValue = Int64(value)
+            encodedValue = convertedValue.bsonBytes
+            encodedType = convertedValue.bsonType
+        }
+        
+    }
+
+    mutating func encode(_ value: Int8) throws {
+        let convertedValue = Int32(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: Int16) throws {
+        let convertedValue = Int32(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: UInt) throws {
+        let convertedValue = UInt64(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: UInt8) throws {
+        let convertedValue = UInt64(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: UInt16) throws {
+        let convertedValue = UInt64(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode(_ value: UInt32) throws {
+        let convertedValue = UInt64(value)
+        encodedValue = convertedValue.bsonBytes
+        encodedType = convertedValue.bsonType
+    }
+
+    mutating func encode<T>(_ value: T) throws where T : Encodable {
+        fatalError("not implemented")
+    }
+}

--- a/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
@@ -7,7 +7,7 @@
 
 import BSONCompose
 
-struct BSONSingleValueEncodingContainer {
+class BSONSingleValueEncodingContainer {
     /// The value assigned to this container.
     var encodedValue: [UInt8]? = nil
 
@@ -16,6 +16,11 @@ struct BSONSingleValueEncodingContainer {
 
     /// The path the encoder took to get to this point, used for error composition.
     var codingPath: [CodingKey]
+
+    /// Initializes a single value container with the provided coding path.
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+    }
 }
 
 extension BSONSingleValueEncodingContainer: ValueProtocol {
@@ -29,48 +34,48 @@ extension BSONSingleValueEncodingContainer: ValueProtocol {
 }
 
 extension BSONSingleValueEncodingContainer: SingleValueEncodingContainer {
-    mutating func encodeNil() throws {
+    func encodeNil() throws {
         encodedValue = []
         encodedType = 10
     }
 
-    mutating func encode(_ value: Bool) throws {
+    func encode(_ value: Bool) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: String) throws {
+    func encode(_ value: String) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: Double) throws {
+    func encode(_ value: Double) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: Int32) throws {
+    func encode(_ value: Int32) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: UInt64) throws {
+    func encode(_ value: UInt64) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: Int64) throws {
+    func encode(_ value: Int64) throws {
         encodedValue = value.bsonBytes
         encodedType = value.bsonType
     }
 
-    mutating func encode(_ value: Float) throws {
+    func encode(_ value: Float) throws {
         let convertedValue = Double(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: Int) throws {
+    func encode(_ value: Int) throws {
         if MemoryLayout<Int>.size == 4 {
             let convertedValue = Int32(value)
             encodedValue = convertedValue.bsonBytes
@@ -83,43 +88,46 @@ extension BSONSingleValueEncodingContainer: SingleValueEncodingContainer {
         
     }
 
-    mutating func encode(_ value: Int8) throws {
+    func encode(_ value: Int8) throws {
         let convertedValue = Int32(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: Int16) throws {
+    func encode(_ value: Int16) throws {
         let convertedValue = Int32(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: UInt) throws {
+    func encode(_ value: UInt) throws {
         let convertedValue = UInt64(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: UInt8) throws {
+    func encode(_ value: UInt8) throws {
         let convertedValue = UInt64(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: UInt16) throws {
+    func encode(_ value: UInt16) throws {
         let convertedValue = UInt64(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode(_ value: UInt32) throws {
+    func encode(_ value: UInt32) throws {
         let convertedValue = UInt64(value)
         encodedValue = convertedValue.bsonBytes
         encodedType = convertedValue.bsonType
     }
 
-    mutating func encode<T>(_ value: T) throws where T : Encodable {
-        fatalError("not implemented")
+    func encode<T>(_ value: T) throws where T : Encodable {
+        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        try value.encode(to: encoder)
+        encodedValue = encoder.bsonBytes
+        encodedType = encoder.bsonType
     }
 }

--- a/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
@@ -1,0 +1,136 @@
+//
+//  BSONUnkeyedEncodingContainer.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+import BSONCompose
+
+class BSONUnkeyedEncodingContainer {
+    /// The contents of this container.
+    var contents: [ValueBox] = []
+
+    /// The path the encoder took to this point.
+    var codingPath: [CodingKey]
+
+    /// Initialies a container with the provided coding path.
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+    }
+}
+
+extension Array where Element == ValueBox {
+    mutating func append<T: ValueProtocol>(_ value: T) {
+        append(ValueBox(value))
+    }
+}
+
+extension BSONUnkeyedEncodingContainer: ValueProtocol {
+    var bsonBytes: [UInt8] {
+        let contents = self.contents
+        return ComposedDocument {
+            ForEach(contents.enumerated()) { index, value in 
+                String(describing: index) => value
+            }
+        }
+        .bsonBytes
+    }
+
+    var bsonType: UInt8 {
+        4
+    }
+}
+
+extension BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    /// The number of elements in this container.
+    var count: Int {
+        contents.count
+    }
+
+    func encode(_ value: String) throws {
+        contents.append(value)
+    }
+
+    func encode(_ value: Double) throws {
+        contents.append(value)
+    }
+
+    func encode(_ value: Float) throws {
+        contents.append(Double(value))
+    }
+
+    func encode(_ value: Int) throws {
+        if MemoryLayout<Int>.size == 4 {
+            contents.append(Int32(value))
+        } else {
+            contents.append(Int64(value))
+        }
+    }
+
+    func encode(_ value: Int8) throws {
+        contents.append(Int32(value))
+    }
+
+    func encode(_ value: Int16) throws {
+        contents.append(Int32(value))
+    }
+
+    func encode(_ value: Int32) throws {
+        contents.append(value)
+    }
+
+    func encode(_ value: Int64) throws {
+        contents.append(value)
+    }
+
+    func encode(_ value: UInt) throws {
+        contents.append(UInt64(value))
+    }
+
+    func encode(_ value: UInt8) throws {
+        contents.append(UInt64(value))
+    }
+
+    func encode(_ value: UInt16) throws {
+        contents.append(UInt64(value))
+    }
+
+    func encode(_ value: UInt32) throws {
+        contents.append(UInt64(value))
+    }
+
+    func encode(_ value: UInt64) throws {
+        contents.append(value)
+    }
+
+    func encode<T: Encodable>(_ value: T) throws {
+        fatalError("not implemented")
+    }
+
+    func encode(_ value: Bool) throws {
+        contents.append(value)
+    }
+
+    func encodeNil() throws {
+        contents.append(Bool?.none)
+    }
+
+    func nestedContainer<NestedKey: CodingKey>(
+        keyedBy keyType: NestedKey.Type
+    ) -> KeyedEncodingContainer<NestedKey> {
+        let nestedContainer = BSONKeyedEncodingContainer<NestedKey>(codingPath: codingPath)
+        contents.append(nestedContainer)
+        return KeyedEncodingContainer(nestedContainer)
+    }
+
+    func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let nestedContainer = BSONUnkeyedEncodingContainer(codingPath: codingPath)
+        contents.append(nestedContainer)
+        return nestedContainer
+    }
+
+    func superEncoder() -> Encoder {
+        fatalError("not implemented")
+    }
+}

--- a/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
@@ -105,7 +105,9 @@ extension BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     }
 
     func encode<T: Encodable>(_ value: T) throws {
-        fatalError("not implemented")
+        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        try value.encode(to: encoder)
+        contents.append(encoder)
     }
 
     func encode(_ value: Bool) throws {
@@ -131,6 +133,8 @@ extension BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     }
 
     func superEncoder() -> Encoder {
-        fatalError("not implemented")
+        let superEncoder = BSONEncodingContainerProvider(codingPath: codingPath)
+        contents.append(superEncoder)
+        return superEncoder
     }
 }

--- a/Sources/BSONEncodable/ValueBox.swift
+++ b/Sources/BSONEncodable/ValueBox.swift
@@ -1,0 +1,29 @@
+//
+//  ValueBox.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+import BSONCompose
+
+/// A box around a value conforming to `ValueProtocol`.
+struct ValueBox {
+    /// The value in this box.
+    let value: ValueProtocol
+
+    /// Boxes the provided value.
+    init<T: ValueProtocol>(_ value: T) {
+        self.value = value
+    }
+}
+
+extension ValueBox: ValueProtocol {
+    var bsonBytes: [UInt8] {
+        value.bsonBytes
+    }
+
+    var bsonType: UInt8 {
+        value.bsonType
+    }
+}

--- a/Tests/BSONEncodableTests/BSONEncoderTests.swift
+++ b/Tests/BSONEncodableTests/BSONEncoderTests.swift
@@ -1,0 +1,34 @@
+//
+//  BSONEncoderTests.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+import BSONEncodable
+import BSONCompose
+import XCTest
+
+class BSONEncoderTests: XCTestCase {
+    struct TestType: Encodable {
+        let name: String
+        let value: Double
+        let list: [Bool]
+    }
+
+    func testEncodesAsExpected() throws {
+        let value = TestType(name: "test", value: 1.23, list: [true, false, true])
+        let encodedValue = try BSONEncoder().encode(value)
+        let expectedBytes = ComposedDocument {
+            "name" => "test"
+            "value" => 1.23
+            "list" => ComposedArrayDocument {
+                "0" => true
+                "1" => false
+                "2" => true
+            }
+        }
+        .bsonBytes
+        XCTAssertEqual(encodedValue, expectedBytes)
+    }
+}

--- a/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
@@ -16,7 +16,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testEncodeNil() throws {
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encodeNil(forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => Int32?.none
@@ -27,7 +27,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeDouble() throws {
         let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -38,7 +38,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeString() throws {
         let value = "test"
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -49,7 +49,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeBool() throws {
         let value = Bool.random()
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -60,7 +60,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeInt32() throws {
         let value = Int32.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -71,7 +71,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeInt64() throws {
         let value = Int64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -82,7 +82,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
 
     func testEncodeUInt64() throws {
         let value = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -94,7 +94,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     func testEncodeOptional() throws {
         try XCTSkipIf(true, "not implemented")
         let value: UInt64? = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
             "test" => value
@@ -104,9 +104,8 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testNestedKeyedContainer() throws {
-        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
-        let value: UInt64? = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let value = UInt64.random(in: .min ... .max)
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         var nestedContainer = container.nestedContainer(keyedBy: Key.self, forKey: .test)
         try nestedContainer.encode(value, forKey: .test)
         let expectedBytes = ComposedDocument {
@@ -121,7 +120,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     func testNestedUnkeyedContainer() throws {
         try XCTSkipIf(true, "we don't have a way to encode an array document in BSONCompose yet")
         let value: UInt64? = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         var nestedContainer = container.nestedUnkeyedContainer(forKey: .test)
         try nestedContainer.encode(value)
         let expectedBytes = ComposedDocument {
@@ -136,7 +135,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     func testSuperEncoderNoKey() throws {
         try XCTSkipIf(true, "reference semantics not yet implemented on this container")
         let value = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         let superEncoder = container.superEncoder()
         try value.encode(to: superEncoder)
         let expectedBytes = ComposedDocument {
@@ -149,7 +148,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     func testSuperEncoderForKey() throws {
         try XCTSkipIf(true, "reference semantics not yet implemented on this container")
         let value = UInt64.random(in: .min ... .max)
-        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         let superEncoder = container.superEncoder(forKey: .test)
         try value.encode(to: superEncoder)
         let expectedBytes = ComposedDocument {

--- a/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
@@ -1,0 +1,161 @@
+//
+// BSONKeyedEncodingContainerTests.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+@testable
+import BSONEncodable
+import BSONCompose
+import XCTest
+
+class BSONKeyedEncodingContainerTests: XCTestCase {
+    enum Key: CodingKey {
+        case test, `super`
+    }
+
+    func testEncodeNil() throws {
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encodeNil(forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => Int32?.none
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeDouble() throws {
+        let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeString() throws {
+        let value = "test"
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeBool() throws {
+        let value = Bool.random()
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeInt32() throws {
+        let value = Int32.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeInt64() throws {
+        let value = Int64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeUInt64() throws {
+        let value = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeOptional() throws {
+        try XCTSkipIf(true, "not implemented")
+        let value: UInt64? = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testNestedKeyedContainer() throws {
+        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
+        let value: UInt64? = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        var nestedContainer = container.nestedContainer(keyedBy: Key.self, forKey: .test)
+        try nestedContainer.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "test" => ComposedDocument {
+                "test" => value
+            }
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testNestedUnkeyedContainer() throws {
+        try XCTSkipIf(true, "we don't have a way to encode an array document in BSONCompose yet")
+        let value: UInt64? = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        var nestedContainer = container.nestedUnkeyedContainer(forKey: .test)
+        try nestedContainer.encode(value)
+        let expectedBytes = ComposedDocument {
+            "test" => ComposedDocument {
+                "0" => value
+            }
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testSuperEncoderNoKey() throws {
+        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
+        let value = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let superEncoder = container.superEncoder()
+        try value.encode(to: superEncoder)
+        let expectedBytes = ComposedDocument {
+            "super" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testSuperEncoderForKey() throws {
+        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
+        let value = UInt64.random(in: .min ... .max)
+        var container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        let superEncoder = container.superEncoder(forKey: .test)
+        try value.encode(to: superEncoder)
+        let expectedBytes = ComposedDocument {
+            "test" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+}  

--- a/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
@@ -92,7 +92,6 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testEncodeOptional() throws {
-        try XCTSkipIf(true, "not implemented")
         let value: UInt64? = UInt64.random(in: .min ... .max)
         let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         try container.encode(value, forKey: .test)
@@ -118,13 +117,12 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testNestedUnkeyedContainer() throws {
-        try XCTSkipIf(true, "we don't have a way to encode an array document in BSONCompose yet")
         let value: UInt64? = UInt64.random(in: .min ... .max)
         let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         var nestedContainer = container.nestedUnkeyedContainer(forKey: .test)
         try nestedContainer.encode(value)
         let expectedBytes = ComposedDocument {
-            "test" => ComposedDocument {
+            "test" => ComposedArrayDocument {
                 "0" => value
             }
         }
@@ -133,7 +131,6 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testSuperEncoderNoKey() throws {
-        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
         let value = UInt64.random(in: .min ... .max)
         let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         let superEncoder = container.superEncoder()
@@ -146,7 +143,6 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
     }
 
     func testSuperEncoderForKey() throws {
-        try XCTSkipIf(true, "reference semantics not yet implemented on this container")
         let value = UInt64.random(in: .min ... .max)
         let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
         let superEncoder = container.superEncoder(forKey: .test)

--- a/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class BSONSingleValueEncodingContainerTests: XCTestCase {
     func testEncodeDouble() throws {
         let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -22,7 +22,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     }
 
     func testEncodeNil() throws {
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encodeNil()
         let expectedBytes = Optional<Bool>.none.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -32,7 +32,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
 
     func testEncodeString() throws {
         let value = "test"
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -42,7 +42,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
 
     func testEncodeBool() throws {
         let value = Bool.random()
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -52,7 +52,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeInt32() throws {
         let value = Int32.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -62,7 +62,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeUInt64() throws {
         let value = UInt64.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -72,7 +72,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeInt64() throws {
         let value = Int64.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -82,7 +82,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeInt() throws {
         let value = Int.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bitWidth == 32 ? Int32(value).bsonBytes : Int64(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -92,7 +92,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeInt8() throws {
         let value = Int8.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = Int32(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -102,7 +102,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeInt16() throws {
         let value = Int16.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = Int32(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -112,7 +112,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeUInt8() throws {
         let value = UInt8.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = UInt64(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -122,7 +122,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeUInt16() throws {
         let value = UInt16.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = UInt64(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -132,7 +132,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeUInt32() throws {
         let value = UInt32.random(in: .min ... .max)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = UInt64(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -142,7 +142,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     
     func testEncodeFloat() throws {
         let value = Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = Double(value).bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
@@ -152,7 +152,7 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
 
     func testEncodeOptional() throws {
         let value: String? = "test"
-        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)
         let expectedBytes = value.bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)

--- a/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
@@ -151,7 +151,6 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
     }
 
     func testEncodeOptional() throws {
-        try XCTSkipIf(true, "not implemented")
         let value: String? = "test"
         var container = BSONSingleValueEncodingContainer(codingPath: [])
         try container.encode(value)

--- a/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
@@ -1,5 +1,5 @@
 //
-//  BSONSingleValueContainerTests.swift
+//  BSONSingleValueEncodingContainerTests.swift
 //
 //
 //  Created by Christopher Richez on March 28th 2022
@@ -10,7 +10,7 @@ import BSONEncodable
 import BSONCompose
 import XCTest
 
-class BSONSingleValueContainerTests: XCTestCase {
+class BSONSingleValueEncodingContainerTests: XCTestCase {
     func testEncodeDouble() throws {
         let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
         var container = BSONSingleValueEncodingContainer(codingPath: [])

--- a/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
@@ -1,0 +1,148 @@
+//
+//  BSONUnkeyedEncodingContainerTests.swift
+//
+//
+//  Created by Christopher Richez on March 31 2022
+//
+
+@testable
+import BSONEncodable
+import BSONCompose
+import XCTest
+
+class BSONUnkeyedEncodingContainerTests: XCTestCase {
+    enum Key: CodingKey {
+        case test
+    }
+
+    func testEncodeDouble() throws {
+        let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeString() throws {
+        let value = "test"
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeBool() throws {
+        let value = Bool.random()
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeNil() throws {
+        let value = Int32?.none
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encodeNil()
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeInt32() throws {
+        let value = Int32.random(in: .min ... .max)
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeUInt64() throws {
+        let value = UInt64.random(in: .min ... .max)
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeInt64() throws {
+        let value = Int64.random(in: .min ... .max)
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testEncodeOptional() throws {
+        try XCTSkipIf(true, "not implemented")
+        let value: Int64? = Int64.random(in: .min ... .max)
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+    
+    func testNestedKeyedContainer() throws {
+        let value = "test"
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        var nestedContainer = container.nestedContainer(keyedBy: Key.self)
+        try nestedContainer.encode(value, forKey: .test)
+        let expectedBytes = ComposedDocument {
+            "0" => ComposedDocument {
+                "test" => value
+            }
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testNestedUnkeyedContainer() throws {
+        try XCTSkipIf(true, "no array documents in BSONCompose yet")
+        let value = "test"
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        var nestedContainer = container.nestedUnkeyedContainer()
+        try nestedContainer.encode(value)
+        let expectedBytes = ComposedDocument {
+            "0" => ComposedDocument {
+                "0" => value
+            }
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    func testSuperEncoder() throws {
+        try XCTSkipIf(true, "not implemented")
+        let value = false
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        let superEncoder = container.superEncoder()
+        try value.encode(to: superEncoder)
+        let expectedBytes = ComposedDocument {
+            "0" => value
+        }
+        .bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+}

--- a/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
@@ -93,7 +93,6 @@ class BSONUnkeyedEncodingContainerTests: XCTestCase {
     }
 
     func testEncodeOptional() throws {
-        try XCTSkipIf(true, "not implemented")
         let value: Int64? = Int64.random(in: .min ... .max)
         let container = BSONUnkeyedEncodingContainer(codingPath: [])
         try container.encode(value)
@@ -119,13 +118,12 @@ class BSONUnkeyedEncodingContainerTests: XCTestCase {
     }
 
     func testNestedUnkeyedContainer() throws {
-        try XCTSkipIf(true, "no array documents in BSONCompose yet")
         let value = "test"
         let container = BSONUnkeyedEncodingContainer(codingPath: [])
         var nestedContainer = container.nestedUnkeyedContainer()
         try nestedContainer.encode(value)
         let expectedBytes = ComposedDocument {
-            "0" => ComposedDocument {
+            "0" => ComposedArrayDocument {
                 "0" => value
             }
         }
@@ -134,7 +132,6 @@ class BSONUnkeyedEncodingContainerTests: XCTestCase {
     }
 
     func testSuperEncoder() throws {
-        try XCTSkipIf(true, "not implemented")
         let value = false
         let container = BSONUnkeyedEncodingContainer(codingPath: [])
         let superEncoder = container.superEncoder()

--- a/Tests/BSONEncodableTests/SingleValueContainerTests.swift
+++ b/Tests/BSONEncodableTests/SingleValueContainerTests.swift
@@ -1,0 +1,163 @@
+//
+//  BSONSingleValueContainerTests.swift
+//
+//
+//  Created by Christopher Richez on March 28th 2022
+//
+
+@testable
+import BSONEncodable
+import BSONCompose
+import XCTest
+
+class BSONSingleValueContainerTests: XCTestCase {
+    func testEncodeDouble() throws {
+        let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+
+    func testEncodeNil() throws {
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encodeNil()
+        let expectedBytes = Optional<Bool>.none.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = Optional<Bool>.none.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+
+    func testEncodeString() throws {
+        let value = "test"
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+
+    func testEncodeBool() throws {
+        let value = Bool.random()
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeInt32() throws {
+        let value = Int32.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeUInt64() throws {
+        let value = UInt64.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeInt64() throws {
+        let value = Int64.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeInt() throws {
+        let value = Int.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bitWidth == 32 ? Int32(value).bsonBytes : Int64(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bitWidth == 32 ? Int32(value).bsonType : Int64(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeInt8() throws {
+        let value = Int8.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = Int32(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = Int32(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeInt16() throws {
+        let value = Int16.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = Int32(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = Int32(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeUInt8() throws {
+        let value = UInt8.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = UInt64(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = UInt64(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeUInt16() throws {
+        let value = UInt16.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = UInt64(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = UInt64(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeUInt32() throws {
+        let value = UInt32.random(in: .min ... .max)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = UInt64(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = UInt64(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+    
+    func testEncodeFloat() throws {
+        let value = Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = Double(value).bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = Double(value).bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+
+    func testEncodeOptional() throws {
+        try XCTSkipIf(true, "not implemented")
+        let value: String? = "test"
+        var container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedBytes = value.bsonBytes
+        XCTAssertEqual(container.bsonBytes, expectedBytes)
+        let expectedType = value.bsonType
+        XCTAssertEqual(container.bsonType, expectedType)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request implements `BSONEncoder`, a `TopLevelEncoder` with an output type of `[UInt8]` suitable for adapting current `Encodable` types for BSON document encoding.
