### PR TITLE
Implement `BSONDecoder`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,11 @@ let package = Package(
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "BSONCompose",
-            targets: ["BSONCompose"]),
-        .library(
-            name: "BSONParse", 
-            targets: ["BSONParse"]),
-        .library(
-            name: "BSONKit", 
-            targets: ["BSONCompose", "BSONParse"])
+        .library(name: "BSONCompose", targets: ["BSONCompose"]),
+        .library(name: "BSONParse", targets: ["BSONParse"]),
+        .library(name: "BSONKit", targets: ["BSONCompose", "BSONParse"]),
+        .library(name: "BSONDecodable", targets: ["BSONDecodable"]),
+        .library(name: "BSONEncodable", targets: ["BSONEncodable"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "1.0.0"))
@@ -29,25 +25,20 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "BSONCompose",
-            dependencies: []),
-        .testTarget(
-            name: "BSONComposeTests",
-            dependencies: ["BSONCompose"]),
+        .target(name: "BSONCompose", dependencies: []),
+        .testTarget(name: "BSONComposeTests", dependencies: ["BSONCompose"]),
+
         .target(
             name: "BSONParse",
             dependencies: [
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ]),
-        .testTarget(
-            name: "BSONParseTests",
-            dependencies: ["BSONParse"]),
-        .target(
-            name: "BSONEncodable",
-            dependencies: ["BSONCompose"]),
-        .testTarget(
-            name: "BSONEncodableTests",
-            dependencies: ["BSONEncodable", "BSONCompose"]),
+        .testTarget(name: "BSONParseTests", dependencies: ["BSONParse"]),
+
+        .target(name: "BSONEncodable", dependencies: ["BSONCompose"]),
+        .testTarget(name: "BSONEncodableTests", dependencies: ["BSONEncodable", "BSONCompose"]),
+
+        .target(name: "BSONDecodable", dependencies: ["BSONParse"]),
+        .testTarget(name: "BSONDecodableTests", dependencies: ["BSONParse", "BSONDecodable"])
     ]
 )

--- a/Sources/BSONDecodable/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BSONDecodable/BSONSingleValueDecodingContainer.swift
@@ -1,0 +1,214 @@
+//
+//  BSONSingleValueDecodingContainer.swift
+//
+//
+//  Created by Christopher Richez on April 3 20222
+//
+
+import BSONParse
+
+struct BSONSingleValueDecodingContainer<Data: Collection> where Data.Element == UInt8 {
+    /// The bytes in this container.
+    let contents: Data
+
+    /// The path the decoder took to this point.
+    let codingPath: [CodingKey]
+}
+
+extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
+    func decodeNil() -> Bool {
+        contents.isEmpty
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch Bool.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 1 byte, but found \(contents.count)",
+                underlyingError: Bool.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(type, context)
+        }
+    }
+
+    func decode(_ type: String.Type) throws -> String {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch String.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "declared size different from actual size",
+                underlyingError: String.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(type, context)
+        } catch String.Error.dataTooShort {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected at least 5 bytes, but found \(contents.count)",
+                underlyingError: String.Error.dataTooShort)
+            throw DecodingError.typeMismatch(type, context)
+        }
+    }
+
+    func decode(_ type: Double.Type) throws -> Double {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch Double.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: Double.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Double.self, context)
+        }
+    }
+
+    func decode(_ type: Float.Type) throws -> Float {
+        do {
+            return Float(try Double(bsonBytes: contents))
+        } catch Double.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: Double.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Float.self, context)
+        }
+    }
+
+    func decode(_ type: Int.Type) throws -> Int {
+        if MemoryLayout<Int>.size == 4 {
+            do {
+                return Int(try Int32(bsonBytes: contents))
+            } catch Int32.Error.sizeMismatch {
+                let context = DecodingError.Context(
+                    codingPath: codingPath, 
+                    debugDescription: "expected 4 bytes, but found \(contents.count)",
+                    underlyingError: Int32.Error.sizeMismatch)
+                throw DecodingError.typeMismatch(Int.self, context)
+            }
+        } else {
+            do {
+                return Int(try Int64(bsonBytes: contents))
+            } catch Int64.Error.sizeMismatch {
+                let context = DecodingError.Context(
+                    codingPath: codingPath, 
+                    debugDescription: "expected 8 bytes, but found \(contents.count)",
+                    underlyingError: Int64.Error.sizeMismatch)
+                throw DecodingError.typeMismatch(Int.self, context)
+            }
+        }
+    }
+
+    func decode(_ type: Int8.Type) throws -> Int8 {
+        do {
+            return Int8(try Int32(bsonBytes: contents))
+        } catch Int32.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 4 bytes, but found \(contents.count)",
+                underlyingError: Int32.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Int8.self, context)
+        }
+    }
+
+    func decode(_ type: Int16.Type) throws -> Int16 {
+        do {
+            return Int16(try Int32(bsonBytes: contents))
+        } catch Int32.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 4 bytes, but found \(contents.count)",
+                underlyingError: Int32.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Int16.self, context)
+        }
+    }
+
+    func decode(_ type: Int32.Type) throws -> Int32 {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch Int32.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 4 bytes, but found \(contents.count)",
+                underlyingError: Int32.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Int32.self, context)
+        }
+    }
+
+    func decode(_ type: Int64.Type) throws -> Int64 {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch Int64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: Int64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(Int64.self, context)
+        }
+    }
+
+    func decode(_ type: UInt.Type) throws -> UInt {
+        do {
+            return UInt(try UInt64(bsonBytes: contents))
+        } catch UInt64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: UInt64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(UInt.self, context)
+        }
+    }
+
+    func decode(_ type: UInt8.Type) throws -> UInt8 {
+        do {
+            return UInt8(try UInt64(bsonBytes: contents))
+        } catch UInt64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: UInt64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(UInt8.self, context)
+        }
+    }
+
+    func decode(_ type: UInt16.Type) throws -> UInt16 {
+        do {
+            return UInt16(try UInt64(bsonBytes: contents))
+        } catch UInt64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: UInt64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(UInt16.self, context)
+        }
+    }
+
+    func decode(_ type: UInt32.Type) throws -> UInt32 {
+        do {
+            return UInt32(try UInt64(bsonBytes: contents))
+        } catch UInt64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: UInt64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(UInt32.self, context)
+        }
+    }
+
+    func decode(_ type: UInt64.Type) throws -> UInt64 {
+        do {
+            return try type.init(bsonBytes: contents)
+        } catch UInt64.Error.sizeMismatch {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: "expected 8 bytes, but found \(contents.count)",
+                underlyingError: UInt64.Error.sizeMismatch)
+            throw DecodingError.typeMismatch(UInt64.self, context)
+        }
+    }
+
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        fatalError("not implemented")
+        // let decoder = DecodingContainerProvider(bsonBytes: contents, codingPath: codingPath)
+        // return try T(from: decoder)
+    }
+}

--- a/Sources/BSONParse/ParsableValue.swift
+++ b/Sources/BSONParse/ParsableValue.swift
@@ -21,7 +21,7 @@ public protocol ParsableValue {
 
 extension Int32: ParsableValue {
     /// The error type thrown by `Int32.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// The data passed to the initializer was not 4 bytes long.
         case sizeMismatch
     }
@@ -41,7 +41,7 @@ extension Int32: ParsableValue {
 
 extension Int64: ParsableValue {
     /// The error type thrown by `Int64.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// The data passed to the initializer was not 8 bytes long.
         case sizeMismatch
     }
@@ -61,7 +61,7 @@ extension Int64: ParsableValue {
 
 extension UInt64: ParsableValue {
     /// The error type thrown by `UInt64.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// The data passed to the initializer was not 8 bytes long.
         case sizeMismatch
     }
@@ -81,7 +81,7 @@ extension UInt64: ParsableValue {
 
 extension Double: ParsableValue {
     /// The error type thrown by `Double.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// The data passed to the initializer was not 8 bytes long.
         case sizeMismatch
     }
@@ -101,7 +101,7 @@ extension Double: ParsableValue {
 
 extension Bool: ParsableValue {
     /// The error type thrown by `Bool.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// The data passed to the initializer was not 1 byte long.
         case sizeMismatch
     }
@@ -119,7 +119,7 @@ extension Bool: ParsableValue {
 
 extension String: ParsableValue {
     /// The error type thrown by `String.init(bsonBytes:)`.
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, Equatable {
         /// Less than 5 bytes were provided to the initializer.
         case dataTooShort
 

--- a/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
@@ -1,0 +1,173 @@
+//
+//  BSONSingleValueDecodingContainerTests.swift
+//
+//
+//  Created by Christopher Richez on April 3 2022
+//
+
+@testable
+import BSONDecodable
+import BSONCompose
+import BSONParse
+import XCTest
+
+class BSONSingleValueDecodingContainerTests: XCTestCase {
+    func testDecodeNil() throws {
+        var bytes: [UInt8] = []
+        let trueContainer = BSONSingleValueDecodingContainer(contents: bytes, codingPath: [])
+        XCTAssertTrue(trueContainer.decodeNil())
+        bytes.append(1)
+        let falseContainer = BSONSingleValueDecodingContainer(contents: bytes, codingPath: [])
+        XCTAssertFalse(falseContainer.decodeNil())
+    }
+
+    // MARK: Bool
+
+    func testBool() throws {
+        let value = Bool.random()
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(Bool.self), value)
+    }
+
+    func testBoolSizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(Bool.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == Bool.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? Bool.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: Double
+
+    func testDouble() throws {
+        let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(Double.self), value)
+    }
+
+    func testDoubleSizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(Double.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == Double.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? Double.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: String
+
+    func testString() throws {
+        let value = "test"
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(String.self), value)
+    }
+
+    func testStringDataTooShort() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(String.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == String.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
+            XCTAssertEqual(underlyingError, .dataTooShort)
+        }
+    }
+
+    func testStringSizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(
+                contents: [9, 0, 0, 0, 0], 
+                codingPath: [])
+            let decodedValue = try container.decode(String.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == String.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: Int32
+
+    func testInt32() throws {
+        let value = Int32.random(in: .min ... .max)
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(Int32.self), value)
+    }
+
+    func testInt32SizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(Int32.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == Int32.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? Int32.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: UInt64
+
+    func testUInt64() throws {
+        let value = UInt64.random(in: .min ... .max)
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(UInt64.self), value)
+    }
+
+    func testUInt64SizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(UInt64.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == UInt64.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? UInt64.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: Int64
+
+    func testInt64() throws {
+        let value = Int64.random(in: .min ... .max)
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(Int64.self), value)
+    }
+
+    func testInt64SizeMismatch() throws {
+        do {
+            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
+            let decodedValue = try container.decode(Int64.self)
+            XCTFail("expected decoding to fail, but returned \(decodedValue)")
+        } catch DecodingError.typeMismatch(let attemptedType, let context) {
+            XCTAssert(attemptedType == Int64.self)
+            XCTAssertTrue(context.codingPath.isEmpty)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? Int64.Error)
+            XCTAssertEqual(underlyingError, .sizeMismatch)
+        }
+    }
+
+    // MARK: Optional
+
+    func testOptional() throws {
+        try XCTSkipIf(true, "not implemented")
+        let value: Int32? = .random(in: .min ... .max)
+        let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
+        XCTAssertEqual(try container.decode(Int32?.self), value)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request exposes the `BSONDecoder` type as an analog to `Foundation.JSONDecoder` and other `Decoder` implementations.

### Design

The decoder uses the same generic constraints as `ParsedDocument`, which allows clients to parse documents from any byte collection.

```swift
struct BSONDecoder {
    func decode<T, Data>(_ type: T.Type, from data: Data) throws -> T
}
```

Unlike `ParsedDocument`, the first iteration of `BSONDecoder` will only support the standard set of `Decodable` primitives:
* `Double`
* `Float`
* `String`
* All `Int` sizes
* All `UInt` sizes

### Implementation

`BSONDecoder` implements all three decoding container types internally:
* `BSONSingleValueDecodingContainer`
* `BSONUnkeyedDecodingContainer`
* `BSONKeyedDecodingContainer`

Each of these is generic over the data type passed to the top-level decoder's `decode(_:from:)` method.

The `Decoder` conforming type for `BSONDecoder` is `DecodingContainerProvider`. It owns the root `ParsedDocument` used for storage and uses it to initialize the keyed and unkeyed decoding containers.

```swift
struct DecodingContainerProvider<Data: Collection>
where Data.Element == UInt8 {
    let doc: ParsedDocument<Data>
}

extension DecodingContainerProvider: Decoder {
    ...
}
```
