### PR TITLE
Fix dependencies for `xcodebuild` support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,13 +7,7 @@ the BSONKit project.
 ## Development Environment
 
 BSONKit is a pure Swift Package Manager Project that supports all Swift platforms for both 
-release and development. The maintainer of this repository uses Visual Studio Code with the 
-Swift Server Work Group's Swift language support extension.
-
-This project should build properly on Xcode, but you may encounter similar problems to
-those described in issue [#2](https://github.com/crichez/swift-bson/issues/2). These are related
-to differences between the Swift open-source toolchain and Xcode's toolchain and are out of my
-control for now.
+release and development.
 
 ## Discussions
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
         run: swift test
 
       - name: Test iOS
-        run: xcodebuild test -scheme swift-bson-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=15.4"
+        run: xcodebuild test -scheme swift-bson-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=15.2"
 
       - name: Test tvOS
-        run: xcodebuild test -scheme swift-bson-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.4"
+        run: xcodebuild test -scheme swift-bson-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
 
       - name: Test watchOS
         run: xcodebuild test -scheme swift-bson-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 40mm,OS=8.3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,22 @@ jobs:
       - name: Test
         run: swift test
 
-  test-macos:
+  test-apple-platforms:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Test macOS
         run: swift test
+
+      - name: Test iOS
+        run: xcodebuild test -scheme swift-bson-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=15.4"
+
+      - name: Test tvOS
+        run: xcodebuild test -scheme swift-bson-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.4"
+
+      - name: Test watchOS
+        run: xcodebuild test -scheme swift-bson-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 40mm,OS=8.3"
 
   test-windows:
     runs-on: windows-latest

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             ]),
         .testTarget(
             name: "BSONParseTests",
-            dependencies: ["BSONParse"]),
+            dependencies: ["BSONParse", "BSONCompose"]),
         .target(
             name: "BSONEncodable",
             dependencies: ["BSONCompose"]),

--- a/Tests/BSONParseTests/ParsableValueTests.swift
+++ b/Tests/BSONParseTests/ParsableValueTests.swift
@@ -6,6 +6,7 @@
 //
 
 import BSONParse
+import BSONCompose
 import XCTest
 
 /// A test suite for the `ParsableValue.init(bsonBytes:)` initializer's code branches.


### PR DESCRIPTION
### Objectives

This pull request fixes dependencies for the `BSONParseTests` target, enables CI builds on all Apple platforms, and closes #2.

### Implementation

Additional dependencies are declared for the `BSONParseTests` target in `Package.swift`, and we now import `BSONCompose` in `Tests/BSONParseTests/ParsableValueTests.swift`

### Additional Context

Somehow using the `swift` command line tool built succesfully even though both the package manifest and the source file were missing a dependency.
