### PR TITLE
Change BSONEncoder output to Data

### DIFF
--- a/Sources/BSONEncodable/BSONEncoder.swift
+++ b/Sources/BSONEncodable/BSONEncoder.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 31 2022
 //
 
+import Foundation
+
 /// Use `BSONEncoder` to encode `Encodable` values into fully-formed BSON documents.
 /// 
 /// - Note: 
@@ -29,9 +31,9 @@ public struct BSONEncoder {
     /// 
     /// - Returns: 
     /// The bytes of the resulting BSON document.
-    public func encode<T: Encodable>(_ value: T) throws -> [UInt8] {
+    public func encode<T: Encodable>(_ value: T) throws -> Data {
         let containerProvider = BSONEncodingContainerProvider(codingPath: [])
         try value.encode(to: containerProvider)
-        return containerProvider.bsonBytes
+        return Data(containerProvider.bsonBytes)
     }
 }

--- a/Tests/BSONEncodableTests/BSONEncoderTests.swift
+++ b/Tests/BSONEncodableTests/BSONEncoderTests.swift
@@ -19,7 +19,7 @@ class BSONEncoderTests: XCTestCase {
     func testEncodesAsExpected() throws {
         let value = TestType(name: "test", value: 1.23, list: [true, false, true])
         let encodedValue = try BSONEncoder().encode(value)
-        let expectedBytes = ComposedDocument {
+        let expectedDoc = ComposedDocument {
             "name" => "test"
             "value" => 1.23
             "list" => ComposedArrayDocument {
@@ -28,7 +28,7 @@ class BSONEncoderTests: XCTestCase {
                 "2" => true
             }
         }
-        .bsonBytes
+        let expectedBytes = Data(expectedDoc.bsonBytes)
         XCTAssertEqual(encodedValue, expectedBytes)
     }
 }


### PR DESCRIPTION
### Objectives

This pull request changes the output type of `BSONEncoder` to `Data` and closes #16.

### Design

See #16.

### Implementation

The final result of `EncodingContainerProvider.bsonBytes` is copied to `Data` just before returning.
