### PR TITLE
Add `BinaryValueProtocol`

### DIFF
--- a/Sources/BSONCompose/Values/BinaryValueProtocol.swift
+++ b/Sources/BSONCompose/Values/BinaryValueProtocol.swift
@@ -1,0 +1,33 @@
+//
+//  BinaryValueProtocol.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+/// A BSON value that declares the `binary` type (5).
+/// 
+/// Conform to `BinaryValueProtocol` instead of `ValueProtocol` for binary values.
+/// Size and subtype metadata are generated for you, and you only need to return the value's
+/// content data.
+public protocol BinaryValueProtocol: ValueProtocol {
+    /// The subtype byte to declare.
+    var bsonSubtype: UInt8 { get }
+
+    /// The bytes of the value itself, not including its size and subtype.
+    var bsonValueBytes: [UInt8] { get }
+}
+
+extension BinaryValueProtocol {
+    public var bsonType: UInt8 {
+        5
+    }
+
+    public var bsonBytes: [UInt8] {
+        let valueBytes = bsonValueBytes
+        var bsonBytes = Int32(valueBytes.count).bsonBytes
+        bsonBytes.append(bsonSubtype)
+        bsonBytes.append(contentsOf: valueBytes)
+        return bsonBytes
+    }
+}

--- a/Sources/BSONCompose/Values/Data+BinaryValueProtocol.swift
+++ b/Sources/BSONCompose/Values/Data+BinaryValueProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  Data+BinaryValueProtocol.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+import Foundation
+
+extension Data: BinaryValueProtocol {
+    public var bsonSubtype: UInt8 {
+        0
+    }
+
+    public var bsonValueBytes: [UInt8] {
+        Array(self)
+    }
+}

--- a/Sources/BSONCompose/Values/UUID+BinaryValueProtocol.swift
+++ b/Sources/BSONCompose/Values/UUID+BinaryValueProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  UUID+BinaryValueProtocol.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+import Foundation
+
+extension UUID: BinaryValueProtocol {
+    public var bsonSubtype: UInt8 {
+        4
+    }
+
+    public var bsonValueBytes: [UInt8] {
+        withUnsafeBytes(of: self) { bytes in 
+            Array(bytes)
+        }
+    }
+}

--- a/Tests/BSONComposeTests/BinaryValueTests.swift
+++ b/Tests/BSONComposeTests/BinaryValueTests.swift
@@ -1,0 +1,44 @@
+//
+//  BinaryValueTests.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+import BSONCompose
+import XCTest
+import Foundation
+
+class BinaryValueTests: XCTestCase {
+    func testUUID() {
+        let id = UUID()
+        let doc = ComposedDocument {
+            "" => id
+        }
+        var expectedDoc: [UInt8] = [
+            /* size: */ 28, 0, 0, 0,
+            /* key: */ 5, 0,
+            /* value size: */ 16, 0, 0, 0,
+            /* subtype: */ 4, 
+        ]
+        expectedDoc.append(contentsOf: withUnsafeBytes(of: id) { Array($0) })
+        expectedDoc.append(0)
+        XCTAssertEqual(doc.bsonBytes, expectedDoc)
+    }
+
+    func testData() {
+        let data = Data([0, 1, 2, 3])
+        let doc = ComposedDocument {
+            "" => data
+        }
+        let expectedDoc: [UInt8] = [
+            /* size: */ 16, 0, 0, 0,
+            /* key: */ 5, 0,
+            /* value size: */ 4, 0, 0, 0,
+            /* subtype: */ 0, 
+            /* value data: */ 0, 1, 2, 3,
+            /* doc terminator: */ 0,
+        ]
+        XCTAssertEqual(doc.bsonBytes, expectedDoc)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request adds a new protocol - `BinaryValueProtocol` - and conforms two foundation types: `UUID` and `Data`. This closes #21.

### Design

`BinaryValueProtocol` refines `ValueProtocol` and provides default implementations for all of that protocol's requirements. This allows clients to quickly implement custom binary types without having to compose metadata manually.

`UUID` conforms to the protocol by declaring subtype 4, and `Data` conforms with subtype 0.

### Implementation

`UUID` conforms by copying its unsafe raw bytes to an array, and `Data` conforms by copying itself to an array using default `Sequence` copy rules.
