### PR TITLE
Implement `ObjectID`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .library(name: "BSONDecodable", targets: ["BSONDecodable"]),
         .library(name: "BSONEncodable", targets: ["BSONEncodable"]),
         .library(name: "BSONCodable", targets: ["BSONEncodable", "BSONDecodable"]),
+        .library(name: "BSONObjectID", targets: ["BSONObjectID"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "1.0.0"))
@@ -26,13 +27,14 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(name: "BSONCompose", dependencies: []),
+        .target(name: "BSONCompose", dependencies: ["BSONObjectID"]),
         .testTarget(name: "BSONComposeTests", dependencies: ["BSONCompose"]),
 
         .target(
             name: "BSONParse",
             dependencies: [
                 .product(name: "OrderedCollections", package: "swift-collections"),
+                "BSONObjectID"
             ]),
         .testTarget( name: "BSONParseTests", dependencies: ["BSONParse", "BSONCompose"]),
 
@@ -43,5 +45,8 @@ let package = Package(
         .testTarget(
             name: "BSONDecodableTests", 
             dependencies: ["BSONParse", "BSONEncodable", "BSONDecodable", "BSONCompose"]),
+        
+        .target(name: "BSONObjectID", dependencies: []),
+        .testTarget(name: "BSONObjectIDTests", dependencies: ["BSONCompose", "BSONParse"]),
     ]
 )

--- a/Sources/BSONCompose/Values/ObjectID+ValueProtocol.swift
+++ b/Sources/BSONCompose/Values/ObjectID+ValueProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ObjectID+ValueProtocol.swift
+//
+//
+//  Created by Christopher Richez on April 16 2022
+//
+
+import BSONObjectID
+
+extension ObjectID: ValueProtocol {
+    public var bsonType: UInt8 { 7 }
+    public var bsonBytes: [UInt8] { withUnsafeBytes(of: self) { Array($0) } }
+}

--- a/Sources/BSONObjectID/ObjectID.swift
+++ b/Sources/BSONObjectID/ObjectID.swift
@@ -1,0 +1,159 @@
+//
+//  ObjectID.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+import Foundation
+
+extension UInt8 {
+    fileprivate static var random: UInt8 { .random(in: .min ... .max) }
+}
+
+/// An object identifier that features a timestamp and increment for change tracking.
+/// 
+/// [Documentation from MongoDB](https://www.mongodb.com/docs/manual/reference/method/ObjectId/)
+public struct ObjectID {
+    /// The number of seconds since the Unix epoch this ID was initialized.
+    /// 
+    /// - Note:
+    /// This property stores the timestamp bytes as a big-endian `Int32`.
+    private let secondsSince1970: Int32
+
+    /// The date this ID was created.
+    public var timestamp: Date {
+        Date(timeIntervalSince1970: Double(secondsSince1970.bigEndian))
+    }
+
+    /// The 5 random bytes of this ID, represented as a tuple of unsigned integers.
+    /// 
+    /// - Note:
+    /// The numerical value of these integers does not have significant meaning, and therefore
+    /// their endianness is irrelevant and should not be manipulated.
+    private let randomBytes: (UInt8, UInt8, UInt8, UInt8, UInt8)
+
+    /// The 3 increment bytes of this ID, represented as a tuple of unsigned integers.
+    /// 
+    /// The increment is a three-byte big-endian signed integer.
+    private var incrementBytes: (UInt8, UInt8, UInt8)
+
+    /// The increment value of this `ObjectID`.
+    /// 
+    /// Increments are randomized at initialization unless read from BSON or hexadecimal data.
+    /// The numerical value of an increment is usually meaningless, but a comparison of two
+    /// `ObjectID` values via their increment can be useful depending on your data model.
+    public private(set) var increment: Int {
+        get {
+            let signum = Int8(truncatingIfNeeded: incrementBytes.2).bigEndian.signum()
+            switch MemoryLayout<Int>.size {
+            case 4:
+                let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 1)
+                let padding: UInt8 = signum == 0 || signum == 1 ? .min : .max
+                withUnsafeBytes(of: (padding, incrementBytes)) { paddedIncrementBytes in 
+                    copyBuffer.copyMemory(from: paddedIncrementBytes)
+                }
+                return copyBuffer.load(as: Int.self).bigEndian
+            case 8:
+                let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 1)
+                let padding: (UInt32, UInt8) = signum == 0 || signum == 1 ? (.min, .min) : (.max, .max)
+                withUnsafeBytes(of: (padding, incrementBytes)) { paddedIncrementBytes in 
+                    copyBuffer.copyMemory(from: paddedIncrementBytes)
+                }
+                return copyBuffer.load(as: Int.self).bigEndian
+            default:
+                fatalError("arch must be 32 or 64 bit")
+            }
+        }
+        set {
+            incrementBytes = withUnsafeBytes(of: newValue.bigEndian) { newValueBytes in 
+                (newValueBytes[5], newValueBytes[6], newValueBytes[7])
+            }
+        }
+    }
+
+    /// Increments this ID by one.
+    public mutating func incrementByOne() {
+        increment &+= 1
+    }
+
+    /// Initializes a random `ObjectID`.
+    public init() {
+        self.secondsSince1970 = Int32(Date().timeIntervalSince1970).bigEndian
+        self.randomBytes = (.random, .random, .random, .random, .random)
+        self.incrementBytes = (.random, .random, .random)
+    }
+}
+
+extension ObjectID: LosslessStringConvertible {
+    public init?(_ description: String) {
+        // Constants
+        let hexCharacters = Array("0123456789abcdef".utf8)
+        let hexStringCodeUnits = Array(description.utf8)
+
+        // Iterator
+        var stringCursor = 0
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(12)
+        while stringCursor < 24 {
+            guard let firstHexCharacterIndex = hexCharacters.firstIndex(of: hexStringCodeUnits[stringCursor]),
+                  let nextHexCharacterIndex = hexCharacters.firstIndex(of: hexStringCodeUnits[stringCursor + 1]) else {
+                return nil
+            }
+            bytes.append(UInt8(firstHexCharacterIndex * 16 + nextHexCharacterIndex))
+            stringCursor += 2
+        }
+
+        // Timestamp read and conversion
+        let timestampBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 1)
+        timestampBuffer.copyBytes(from: bytes[0..<4])
+        self.secondsSince1970 = timestampBuffer.load(as: Int32.self)
+
+        // Read the random bytes
+        let randomBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 5, alignment: 1)
+        randomBuffer.copyBytes(from: bytes[4..<9])
+        self.randomBytes = randomBuffer.load(as: (UInt8, UInt8, UInt8, UInt8, UInt8).self)
+
+        // Read the increment bytes
+        let incrementBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: 1)
+        incrementBuffer.copyBytes(from: bytes[9..<12])
+        self.incrementBytes = incrementBuffer.load(as: (UInt8, UInt8, UInt8).self)
+    }
+    
+    public var description: String {
+        var bytes = withUnsafeBytes(of: secondsSince1970) { timestampBytes in
+            Array(timestampBytes)
+        }
+        withUnsafeBytes(of: (randomBytes, incrementBytes)) { otherBytes in 
+            bytes.append(contentsOf: otherBytes)
+        }
+        let hexCharacters = Array("0123456789abcdef".utf8)
+        var hexStringCodeUnits: [UInt8] = []
+        hexStringCodeUnits.reserveCapacity(24)
+        for byte in bytes {
+            hexStringCodeUnits.append(hexCharacters[Int(byte / 16)])
+            hexStringCodeUnits.append(hexCharacters[Int(byte % 16)])
+        }
+        return String(decoding: hexStringCodeUnits, as: UTF8.self)
+    }
+}
+
+extension ObjectID: ExpressibleByStringLiteral {
+    public init(stringLiteral: String) {
+        self.init(stringLiteral)!
+    }
+}
+
+extension ObjectID: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.secondsSince1970 == rhs.secondsSince1970 &&
+        lhs.randomBytes == rhs.randomBytes &&
+        lhs.incrementBytes == rhs.incrementBytes
+    }
+}
+
+extension ObjectID: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        withUnsafeBytes(of: self) { hasher.combine(bytes: $0) }
+    }
+}

--- a/Sources/BSONParse/ObjectID+ParsableValue.swift
+++ b/Sources/BSONParse/ObjectID+ParsableValue.swift
@@ -1,0 +1,22 @@
+//
+//  ObjectID+ParsableValue.swift
+//
+//
+//  Created by Christopher Richez on April 16 2022
+//
+
+import BSONObjectID
+
+extension ObjectID: ParsableValue {
+    public enum Error: Swift.Error {
+        /// The data passed to `init(bsonBytes:)` was not exactly 12 bytes long.
+        case sizeMismatch
+    }
+
+    public init<Data>(bsonBytes data: Data) throws where Data : Collection, Data.Element == UInt8 {
+        guard data.count == 12 else { throw Error.sizeMismatch }
+        let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 12, alignment: 1)
+        copyBuffer.copyBytes(from: data)
+        self = copyBuffer.load(as: ObjectID.self)
+    }
+}

--- a/Tests/BSONObjectIDTests/ObjectIDTests.swift
+++ b/Tests/BSONObjectIDTests/ObjectIDTests.swift
@@ -1,0 +1,75 @@
+//
+//  ObjectIDTests.swift
+//
+//
+//  Created by Christopher Richez on April 14 2022
+//
+
+import BSONObjectID
+import BSONCompose
+import BSONParse
+import XCTest
+import Foundation
+
+class ObjectIDTests: XCTestCase {
+    /// Asserts converting an ObjectID to and from its hexadecimal string representation
+    /// results in the same binary representation.
+    func testHexStringConversion() {
+        let originalID = ObjectID()
+        let hexID = originalID.description
+        let decodedID = ObjectID(hexID)
+        XCTAssertEqual(originalID.bsonBytes, decodedID.bsonBytes)
+    }
+
+    /// Asserts `ObjectID.bsonBytes` returns the expected bytes for a known id.
+    func testBSONBytes() {
+        let id = ObjectID()
+        let encodedID = id.bsonBytes
+        withUnsafeBytes(of: id) { idBytes in 
+            XCTAssertEqual(encodedID, Array(idBytes))
+        }
+    }
+
+    /// Asserts `ObjectID.init(bsonBytes:)` initializes the expected id for known data.
+    func testInitFromBSONBytes() throws {
+        let id = ObjectID()
+        let decodedID = try ObjectID(bsonBytes: id.bsonBytes)
+        XCTAssertEqual(id.bsonBytes, decodedID.bsonBytes)
+    }
+
+    /// Asserts the creation timestamp of the ID is roughly that of the current date,
+    /// with a 1 second margin considering execution timing.
+    func testTimestampAccurate() throws {
+        let id = ObjectID()
+        let nowish = Date()
+        XCTAssertTrue(DateInterval(start: id.timestamp, end: nowish).duration < 1)
+    }
+
+    /// Asserts converting an id to and from its description results in the same timestamp.
+    func testTimestampConsistent() throws {
+        let id = ObjectID()
+        let hexID = id.description
+        let idFromHex = ObjectID(hexID)!
+        XCTAssertEqual(id.timestamp, idFromHex.timestamp)
+    }
+
+    /// Asserts converting an id to and from its description results in the same timestamp.
+    func testIncrementConsistent() throws {
+        let id = ObjectID()
+        let hexID = id.description
+        let idFromHex = ObjectID(hexID)!
+        XCTAssertEqual(id.increment, idFromHex.increment)
+    }
+
+    /// Asserts `incrementByOne()` actually increments the ID by one.
+    func testIncrementByOne() {
+        var id = ObjectID()
+        let originalIncrement = id.increment
+        guard originalIncrement < .max else {
+            testIncrementByOne()
+            return
+        }
+        id.incrementByOne()
+        XCTAssertEqual(originalIncrement + 1, id.increment)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request implements the BSON `ObjectID` type in the `BSONObjectID` module, and closes #22.

### Design

`ObjectID` conforms to `ExpressibleByStringLiteral`, `LosslessStringConvertible` (to and from hex strings), `Equatable`, `Hashable`, and of course `ValueProtocol` and `ParsableValue` when the appropriate modules are imported.

The `timestamp` property uses `Foundation.Date` to fit into existing Swift projects, and the `increment` is exposed as an `Int` for easy version calculations. It can be mutated only through the `incrementByOne()` method.

### Implementation

The type is a `struct` to enable finer in-memory arrangement. Its stored properties are ordered as follows:

```swift
public struct ObjectID {
    let secondsSince1970: Int32
    let randomBytes: (UInt8, UInt8, UInt8, UInt8, UInt8)
    let incrementBytes: (UInt8, UInt8, UInt8)
}
```

Since the specification requires the timestamp and increment to be stored as big-endians, they expose more convenient platform-endian APIs:

```swift
extension ObjectID {
    public var timestamp: Date { ... }
    public private(set) increment: Int {
        get { ... }
        set { ... }
    }
}
```

Since hexadecimal string conversion is a key feature of ObjectID, its `LosslessStringConvertible` conformance imeplements this functionality manually. `ExpressibleByStringLiteral` re-uses that conformance but force-unwraps to intialize, making it trigger a runtime error if the string is not a valid 12-byte hex string.
