### PR TITLE
Remove the `ParsableValue.Error` associated type

### DIFF
--- a/Sources/BSONDecodable/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BSONDecodable/BSONSingleValueDecodingContainer.swift
@@ -20,190 +20,86 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
         contents.isEmpty
     }
 
-    func decode(_ type: Bool.Type) throws -> Bool {
+    private func read<T: ParsableValue>(_ type: T.Type) throws -> T {
         do {
             return try type.init(bsonBytes: contents)
-        } catch Bool.Error.sizeMismatch {
+        } catch ValueParseError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
-                debugDescription: "expected 1 byte, but found \(contents.count)",
-                underlyingError: Bool.Error.sizeMismatch)
+                debugDescription: """
+                    expected at least \(needAtLeast) bytes for a \(type), but found \(contents.count)
+                """,
+                underlyingError: ValueParseError.dataTooShort(needAtLeast, have))
+            throw DecodingError.typeMismatch(type, context)
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            let context = DecodingError.Context(
+                codingPath: codingPath, 
+                debugDescription: """
+                    expected \(need) bytes for a \(type), but found \(contents.count)
+                """,
+                underlyingError: ValueParseError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
         }
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        try read(type)
     }
 
     func decode(_ type: String.Type) throws -> String {
-        do {
-            return try type.init(bsonBytes: contents)
-        } catch String.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "declared size different from actual size",
-                underlyingError: String.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(type, context)
-        } catch String.Error.dataTooShort {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected at least 5 bytes, but found \(contents.count)",
-                underlyingError: String.Error.dataTooShort)
-            throw DecodingError.typeMismatch(type, context)
-        }
+        try read(type)
     }
 
     func decode(_ type: Double.Type) throws -> Double {
-        do {
-            return try type.init(bsonBytes: contents)
-        } catch Double.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: Double.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Double.self, context)
-        }
+        try read(type)
     }
 
     func decode(_ type: Float.Type) throws -> Float {
-        do {
-            return Float(try Double(bsonBytes: contents))
-        } catch Double.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: Double.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Float.self, context)
-        }
+        Float(try read(Double.self))
     }
 
     func decode(_ type: Int.Type) throws -> Int {
         if MemoryLayout<Int>.size == 4 {
-            do {
-                return Int(try Int32(bsonBytes: contents))
-            } catch Int32.Error.sizeMismatch {
-                let context = DecodingError.Context(
-                    codingPath: codingPath, 
-                    debugDescription: "expected 4 bytes, but found \(contents.count)",
-                    underlyingError: Int32.Error.sizeMismatch)
-                throw DecodingError.typeMismatch(Int.self, context)
-            }
+            return Int(try read(Int32.self))
         } else {
-            do {
-                return Int(try Int64(bsonBytes: contents))
-            } catch Int64.Error.sizeMismatch {
-                let context = DecodingError.Context(
-                    codingPath: codingPath, 
-                    debugDescription: "expected 8 bytes, but found \(contents.count)",
-                    underlyingError: Int64.Error.sizeMismatch)
-                throw DecodingError.typeMismatch(Int.self, context)
-            }
+            return Int(try read(Int64.self))
         }
     }
 
     func decode(_ type: Int8.Type) throws -> Int8 {
-        do {
-            return Int8(try Int32(bsonBytes: contents))
-        } catch Int32.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 4 bytes, but found \(contents.count)",
-                underlyingError: Int32.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Int8.self, context)
-        }
+        Int8(try read(Int32.self))
     }
 
     func decode(_ type: Int16.Type) throws -> Int16 {
-        do {
-            return Int16(try Int32(bsonBytes: contents))
-        } catch Int32.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 4 bytes, but found \(contents.count)",
-                underlyingError: Int32.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Int16.self, context)
-        }
+        Int16(try read(Int32.self))
     }
 
     func decode(_ type: Int32.Type) throws -> Int32 {
-        do {
-            return try type.init(bsonBytes: contents)
-        } catch Int32.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 4 bytes, but found \(contents.count)",
-                underlyingError: Int32.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Int32.self, context)
-        }
+        try read(type)
     }
 
     func decode(_ type: Int64.Type) throws -> Int64 {
-        do {
-            return try type.init(bsonBytes: contents)
-        } catch Int64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: Int64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(Int64.self, context)
-        }
+        try read(type)
     }
 
     func decode(_ type: UInt.Type) throws -> UInt {
-        do {
-            return UInt(try UInt64(bsonBytes: contents))
-        } catch UInt64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: UInt64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(UInt.self, context)
-        }
+        UInt(try read(UInt64.self))
     }
 
     func decode(_ type: UInt8.Type) throws -> UInt8 {
-        do {
-            return UInt8(try UInt64(bsonBytes: contents))
-        } catch UInt64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: UInt64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(UInt8.self, context)
-        }
+        UInt8(try read(UInt64.self))
     }
 
     func decode(_ type: UInt16.Type) throws -> UInt16 {
-        do {
-            return UInt16(try UInt64(bsonBytes: contents))
-        } catch UInt64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: UInt64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(UInt16.self, context)
-        }
+        UInt16(try read(UInt64.self))
     }
 
     func decode(_ type: UInt32.Type) throws -> UInt32 {
-        do {
-            return UInt32(try UInt64(bsonBytes: contents))
-        } catch UInt64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: UInt64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(UInt32.self, context)
-        }
+        UInt32(try read(UInt64.self))
     }
 
     func decode(_ type: UInt64.Type) throws -> UInt64 {
-        do {
-            return try type.init(bsonBytes: contents)
-        } catch UInt64.Error.sizeMismatch {
-            let context = DecodingError.Context(
-                codingPath: codingPath, 
-                debugDescription: "expected 8 bytes, but found \(contents.count)",
-                underlyingError: UInt64.Error.sizeMismatch)
-            throw DecodingError.typeMismatch(UInt64.self, context)
-        }
+        try read(type)
     }
 
     func decode<T>(_ type: T.Type) throws -> T where T : Decodable {

--- a/Sources/BSONParse/ObjectID+ParsableValue.swift
+++ b/Sources/BSONParse/ObjectID+ParsableValue.swift
@@ -8,13 +8,8 @@
 import BSONObjectID
 
 extension ObjectID: ParsableValue {
-    public enum Error: Swift.Error {
-        /// The data passed to `init(bsonBytes:)` was not exactly 12 bytes long.
-        case sizeMismatch
-    }
-
     public init<Data>(bsonBytes data: Data) throws where Data : Collection, Data.Element == UInt8 {
-        guard data.count == 12 else { throw Error.sizeMismatch }
+        guard data.count == 12 else { throw ValueParseError.sizeMismatch(12, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 12, alignment: 1)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: ObjectID.self)

--- a/Sources/BSONParse/ParsableValue.swift
+++ b/Sources/BSONParse/ParsableValue.swift
@@ -7,32 +7,18 @@
 
 /// A value that can be parsed from its encoded BSON representation.
 public protocol ParsableValue {
-    /// The error type thrown when parsing this value fails.
-    associatedtype Error: Swift.Error
-
     /// Initializes this value from the provided BSON bytes.
     /// 
     /// - Parameter data: the encoded value, usually returned by the `ParsedDocument` subscript
     /// 
     /// - Throws:
-    /// An `Error` if the value couldn't be parsed.
+    /// A `ValueParseError` appropriate for the type to initialize.
     init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8
 }
 
 extension Int32: ParsableValue {
-    /// The error type thrown by `Int32.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// The data passed to the initializer was not 4 bytes long.
-        case sizeMismatch
-    }
-    
-    /// Initializes a value from its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of exactly 4 bytes that represent an `Int32`
-    /// 
-    /// - Throws: `Int32.Error.sizeMismatch` if `data` was not exactly 4 bytes.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 4 else { throw Error.sizeMismatch }
+        guard data.count == 4 else { throw ValueParseError.sizeMismatch(4, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 4)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int32.self)
@@ -40,19 +26,8 @@ extension Int32: ParsableValue {
 }
 
 extension Int64: ParsableValue {
-    /// The error type thrown by `Int64.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// The data passed to the initializer was not 8 bytes long.
-        case sizeMismatch
-    }
-
-    /// Initializes a value from its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of exactly 8 bytes that represent an `Int64`
-    /// 
-    /// - Throws: `Int64.Error.sizeMismatch` if `data` was not exactly 8 bytes.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw Error.sizeMismatch }
+        guard data.count == 8 else { throw ValueParseError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int64.self)
@@ -60,19 +35,8 @@ extension Int64: ParsableValue {
 }
 
 extension UInt64: ParsableValue {
-    /// The error type thrown by `UInt64.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// The data passed to the initializer was not 8 bytes long.
-        case sizeMismatch
-    }
-    
-    /// Initializes a value fom its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of exactly 8 bytes that represent an `UInt64`.
-    /// 
-    /// - Throws: `Int64.Error.sizeMismatch` if `data` was not exactly 8 bytes.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw Error.sizeMismatch }
+        guard data.count == 8 else { throw ValueParseError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: UInt64.self)
@@ -80,19 +44,8 @@ extension UInt64: ParsableValue {
 }
 
 extension Double: ParsableValue {
-    /// The error type thrown by `Double.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// The data passed to the initializer was not 8 bytes long.
-        case sizeMismatch
-    }
-    
-    /// Initializes a value from its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of exactly 8 bytes that represent a `Double`.
-    /// 
-    /// - Throws: `Double.Error.sizeMismatch` if `data` was not exactly 8 bytes.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw Error.sizeMismatch }
+        guard data.count == 8 else { throw ValueParseError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Double.self)
@@ -100,49 +53,22 @@ extension Double: ParsableValue {
 }
 
 extension Bool: ParsableValue {
-    /// The error type thrown by `Bool.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// The data passed to the initializer was not 1 byte long.
-        case sizeMismatch
-    }
-    
-    /// Initializes a value from its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of exactly 1 byte that represents a `Bool`
-    /// 
-    /// - Throws: `Bool.Error.sizeMismatch` if `data` was not exactly 8 bytes.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 1 else { throw Error.sizeMismatch }
+        guard data.count == 1 else { throw ValueParseError.sizeMismatch(1, data.count) }
         self = data[data.startIndex] == 0 ? false : true
     }
 }
 
 extension String: ParsableValue {
-    /// The error type thrown by `String.init(bsonBytes:)`.
-    public enum Error: Swift.Error, Equatable {
-        /// Less than 5 bytes were provided to the initializer.
-        case dataTooShort
-
-        /// The declared size of the encoded string did not match the number of bytes passed
-        /// to the initializer. For a size of `n`, the data passed to the initializer should 
-        /// have a `count` of `n + 4`.
-        case sizeMismatch
-    }
-    
-    /// Initializes a value from its BSON-encoded bytes.
-    /// 
-    /// - Parameter data: a collection of 5 or more bytes that represent a BSON-encoded `String`
-    /// 
-    /// - Throws:
-    /// `String.Error.dataTooShort` if less than 5 bytes were passed to the initializer.
-    /// `String.Error.sizeMismatch` if the declared and actual size of the `String` did not match.
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count > 4 else { throw Error.dataTooShort }
+        guard data.count > 4 else { throw ValueParseError.dataTooShort(5, data.count) }
         let sizeStart = data.startIndex
         let sizeEnd = data.index(sizeStart, offsetBy: 4)
         // We try! here since we already ensured we have four bytes to read
         let size = Int(try! Int32(bsonBytes: data[sizeStart..<sizeEnd]))
-        guard data.count == size + 4 else { throw Error.sizeMismatch }
+        guard data.count == size + 4 else { 
+            throw ValueParseError.sizeMismatch(size + 4, data.count) 
+        }
         self.init(decoding: data[sizeEnd..<data.index(data.endIndex, offsetBy: -1)], as: UTF8.self)
     }
 }

--- a/Sources/BSONParse/ValueParseError.swift
+++ b/Sources/BSONParse/ValueParseError.swift
@@ -1,0 +1,19 @@
+//
+//  ValueParseError.swift
+//
+//
+//  Created by Christopher Richez on April 16 2022
+//
+
+/// An error that occured while parsing a BSON value.
+public enum ValueParseError: Error, Equatable {
+    /// The data passed to the initializer was shorter than the required metadata for this value.
+    /// 
+    /// This case provides the expected and actual size of the data passed to the initializer.
+    case dataTooShort(_ needAtLeast: Int, _ found: Int)
+
+    /// The data passed to the initializer was not the expected size for this type.
+    /// 
+    /// This case provides the expected and actual size of the data passed to the initializer.
+    case sizeMismatch(_ expected: Int, _ have: Int)
+}

--- a/Tests/BSONDecodableTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONKeyedDecodingContainerTests.swift
@@ -75,8 +75,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Double.Error)
-            XCTAssertEqual(underlyingError, Double.Error.sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                ValueParseError.sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Int32>.size))
         }
     }
 
@@ -101,8 +103,8 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .dataTooShort)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Int32>.size))
         }
     }
 
@@ -118,8 +120,8 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(underlyingError, .sizeMismatch(6, 8))
         }
     }
 
@@ -144,8 +146,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Bool.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<UInt64>.size))
         }
     }
 
@@ -171,8 +175,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Int32.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<UInt64>.size))
         }
     }
 
@@ -198,8 +204,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Int64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
         }
     }
 
@@ -225,8 +233,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? UInt64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))
         }
     }
 

--- a/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
@@ -30,15 +30,17 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testBoolSizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(Bool.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Bool.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Bool>.size, container.contents.count))
         }
     }
 
@@ -51,15 +53,17 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testDoubleSizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(Double.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Double.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Double>.size, container.contents.count))
         }
     }
 
@@ -72,30 +76,34 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testStringDataTooShort() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(String.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .dataTooShort)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .dataTooShort(5, container.contents.count))
         }
     }
 
     func testStringSizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(
+            contents: [9, 0, 0, 0, 0], 
+            codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(
-                contents: [9, 0, 0, 0, 0], 
-                codingPath: [])
             let decodedValue = try container.decode(String.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(13, container.contents.count))
         }
     }
 
@@ -108,15 +116,17 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testInt32SizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(Int32.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Int32.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int32>.size, container.contents.count))
         }
     }
 
@@ -129,15 +139,17 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testUInt64SizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(UInt64.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? UInt64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<UInt64>.size, container.contents.count))
         }
     }
 
@@ -150,15 +162,17 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     }
 
     func testInt64SizeMismatch() throws {
+        let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
         do {
-            let container = BSONSingleValueDecodingContainer(contents: [1, 2, 3], codingPath: [])
             let decodedValue = try container.decode(Int64.self)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? Int64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int64>.size, container.contents.count))
         }
     }
 

--- a/Tests/BSONDecodableTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONUnkeyedDecodingContainerTests.swift
@@ -54,8 +54,10 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? Double.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Bool>.size))
         }
     }
 
@@ -79,13 +81,13 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .dataTooShort)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Bool>.size))
         }
     }
 
     func testStringSizeMismatch() throws {
-        let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        let value = Int64(9)
         let doc = ComposedDocument { "0" => value }
         let parsedDoc = try ParsedDocument(bsonBytes: doc.bsonBytes)
         var container = BSONUnkeyedDecodingContainer(doc: parsedDoc)
@@ -96,8 +98,8 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? String.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(underlyingError, .sizeMismatch(13, MemoryLayout<Int64>.size))
         }
     }
 
@@ -121,8 +123,10 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? Bool.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<Double>.size))
         }
     }
 
@@ -146,8 +150,10 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? Int32.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<Double>.size))
         }
     }
 
@@ -171,8 +177,10 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? Int64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
         }
     }
 
@@ -196,8 +204,10 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? UInt64.Error)
-            XCTAssertEqual(underlyingError, .sizeMismatch)
+                context.underlyingError as? ValueParseError)
+            XCTAssertEqual(
+                underlyingError, 
+                .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))
         }
     }
 

--- a/Tests/BSONParseTests/ParsableValueTests.swift
+++ b/Tests/BSONParseTests/ParsableValueTests.swift
@@ -20,15 +20,16 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts attempting to decode a `Double` from other than 8 bytes throws
-    /// `Double.Error.sizeMismatch`.
+    /// Asserts attempting to decode a `Double` from other than 8 bytes throws the appropriate
+    /// error with the expected attached values.
     func testDoubleSizeMismatch() throws {
+        let faultyBytes: [UInt8] = [0, 1, 2, 3]
         do {
-            let faultyBytes: [UInt8] = [0, 1, 2, 3]
             let decodedValue = try Double(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch Double.Error.sizeMismatch {
-            return
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, MemoryLayout<Double>.size)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 
@@ -41,29 +42,31 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts attempting to decode a `String` from less than 5 bytes throws
-    /// `String.Error.dataTooShort`.
+    /// Asserts attempting to decode a `String` from less than 5 bytes throws the appropriate
+    /// error with the expected attached values.
     func testStringDataTooShort() throws {
+        let faultyBytes: [UInt8] = [0, 1, 2]
         do {
-            let faultyBytes: [UInt8] = [0, 1, 2]
             let decodedValue = try String(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch String.Error.dataTooShort {
-            return
+        } catch ValueParseError.dataTooShort(let needAtLeast, let have) {
+            XCTAssertEqual(needAtLeast, 5)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 
     /// Asserts attempting to decode a `String` with a declared size different from its
-    /// actual size throws `String.Error.sizeMismatch`.
+    /// actual size throws the appropriate error with the expected attached values.
     func testStringSizeMismatch() throws {
+        let value = "this is a test! \u{10097}"
+        var encodedValue = value.bsonBytes
         do {
-            let value = "this is a test! \u{10097}"
-            var encodedValue = value.bsonBytes
-            encodedValue.replaceSubrange(0..<4, with: Int32(5).bsonBytes)
+            encodedValue.replaceSubrange(0..<4, with: Int32(100).bsonBytes)
             let decodedValue = try String(bsonBytes: encodedValue)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch String.Error.sizeMismatch {
-            return
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, 104)
+            XCTAssertEqual(have, encodedValue.count)
         }
     }
 
@@ -76,14 +79,16 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts decoding a `Bool` from more than 1 byte throws `Bool.Error.sizeMismatch`.
+    /// Asserts decoding a `Bool` from more than 1 byte throws the appropriate error with the
+    /// expected attached values.
     func testBoolSizeMismatch() throws {
         let faultyBytes = [UInt8](repeating: 1, count: 3)
         do {
             let decodedValue = try Bool(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch Bool.Error.sizeMismatch {
-            // This is expected
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, MemoryLayout<Bool>.size)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 
@@ -96,14 +101,16 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts decoding an `Int32` from less than 4 bytes throws `Int32.Error.sizeMismatch`.
+    /// Asserts decoding an `Int32` from less than 4 bytes throws the appropriate error with the
+    /// expected attached values.
     func testInt32SizeMismatch() throws {
         let faultyBytes = [UInt8](repeating: 1, count: 3)
         do {
             let decodedValue = try Int32(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch Int32.Error.sizeMismatch {
-            // This is expected
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, MemoryLayout<Int32>.size)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 
@@ -116,14 +123,16 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts decoding a `UInt64` from less than 4 bytes throws `UInt64.Error.sizeMismatch`.
+    /// Asserts decoding a `UInt64` from less than 4 bytes throws the appropriate error with the
+    /// expected attached values.
     func testUInt64SizeMismatch() throws {
         let faultyBytes = [UInt8](repeating: 1, count: 3)
         do {
             let decodedValue = try UInt64(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch UInt64.Error.sizeMismatch {
-            // This is expected
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, MemoryLayout<UInt64>.size)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 
@@ -136,14 +145,16 @@ class ParsableValueTests: XCTestCase {
         XCTAssertEqual(value, decodedValue)
     }
 
-    /// Asserts decoding a `Int64` from less than 4 bytes throws `Int64.Error.sizeMismatch`.
+    /// Asserts decoding a `Int64` from less than 4 bytes throws the appropriate error with the 
+    /// expected attached values.
     func testInt64SizeMismatch() throws {
         let faultyBytes = [UInt8](repeating: 1, count: 3)
         do {
             let decodedValue = try Int64(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch Int64.Error.sizeMismatch {
-            // This is expected
+        } catch ValueParseError.sizeMismatch(let need, let have) {
+            XCTAssertEqual(need, MemoryLayout<Int64>.size)
+            XCTAssertEqual(have, faultyBytes.count)
         }
     }
 }


### PR DESCRIPTION
### Objectives

This pull request removes the `Error` associated type from the `ParsableValue` protocol definition and replaces it with the `ValueParseError` enumeration. This closes #25.

### Design

There were only two errors possible for non-document types, so they were moved to a new enumeration. This should make generic code easier to write, and make error captures simpler where the throwing block initializes more than one type.

```swift
do {
    let one = Int32(bsonBytes: oneData)
    let two = Int64(bsonBytes: twoData)
} catch ValueParseError.sizeMismatch(let need, let have) {
    print("size mismatch: expected \(need) bytes but found \(have)")
}
```

### Implementation

`ValueParseError` also conforms to `Equatable` to facilitate testing. Two attached values were added for each case that should help the caller determine whether the error comes from their part or form corrupt or invalid data.

```swift
public enum ValueParseError: Error, Equatable {
    /// The data passed to the initializer was shorter than the required metadata for this value.
    /// 
    /// This case provides the expected and actual size of the data passed to the initializer.
    case dataTooShort(_ needAtLeast: Int, _ found: Int)

    /// The data passed to the initializer was not the expected size for this type.
    /// 
    /// This case provides the expected and actual size of the data passed to the initializer.
    case sizeMismatch(_ expected: Int, _ have: Int)
}
```
