### PR TITLE
Add `BinaryParsableValue` then conform `Data` & `UUID`

### DIFF
--- a/Sources/BSONParse/BinaryParsableValue.swift
+++ b/Sources/BSONParse/BinaryParsableValue.swift
@@ -1,0 +1,29 @@
+//
+//  BinaryParsableValue.swift
+//  
+//
+//  Created by Christopher Richez on 4/28/22.
+//
+
+/// A BSON value whose encoded form declares the BSON binary type (5).
+///
+/// Conform to `BinaryParsableValue` for BSON binary values to inherit metadata parsing.
+public protocol BinaryParsableValue: ParsableValue {
+    /// Initializes a value from the provided BSON data.
+    ///
+    /// - Parameter bsonValueBytes: the value's encoded bytes, not including size and subtype bytes
+    ///
+    /// - Throws: The appropriate ``ValueParseError``.
+    init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8
+}
+
+extension BinaryParsableValue {
+    public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
+        guard data.count >= 5 else { throw ValueParseError.dataTooShort(5, data.count) }
+        let declaredSize = Int(truncatingIfNeeded: try Int32(bsonBytes: data.prefix(4)))
+        guard data.count == declaredSize + 5 else {
+            throw ValueParseError.sizeMismatch(declaredSize + 5, data.count)
+        }
+        try self.init(bsonValueBytes: data.dropFirst(5))
+    }
+}

--- a/Sources/BSONParse/Data+ParsableValue.swift
+++ b/Sources/BSONParse/Data+ParsableValue.swift
@@ -1,0 +1,14 @@
+//
+//  Data+ParsableValue.swift
+//  
+//
+//  Created by Christopher Richez on 4/28/22.
+//
+
+import Foundation
+
+extension Data: BinaryParsableValue {
+    public init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8 {
+        self.init(bsonValueBytes)
+    }
+}

--- a/Sources/BSONParse/UUID+ParsableValue.swift
+++ b/Sources/BSONParse/UUID+ParsableValue.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Christopher Richez on 4/28/22.
+//
+
+import Foundation
+
+extension UUID: BinaryParsableValue {
+    public init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8 {
+        guard bsonValueBytes.count == 16 else {
+            throw ValueParseError.sizeMismatch(16, bsonValueBytes.count)
+        }
+        let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 16, alignment: 1)
+        copyBuffer.copyBytes(from: bsonValueBytes)
+        self = copyBuffer.load(as: UUID.self)
+    }
+}

--- a/Tests/BSONParseTests/BinaryParsableValueTests.swift
+++ b/Tests/BSONParseTests/BinaryParsableValueTests.swift
@@ -1,0 +1,27 @@
+//
+//  BinaryParsableValueTests.swift
+//  
+//
+//  Created by Christopher Richez on 4/28/22.
+//
+
+import Foundation
+import XCTest
+import BSONParse
+import BSONCompose
+
+class BinaryParsableValueTests: XCTestCase {
+    func testUUID() throws {
+        let value = UUID()
+        let encodedValue = value.bsonBytes
+        let decodedValue = try UUID(bsonBytes: encodedValue)
+        XCTAssertEqual(value, decodedValue)
+    }
+    
+    func testData() throws {
+        let value = Data([1, 2, 3, 4])
+        let encodedValue = value.bsonBytes
+        let decodedValue = try Data(bsonBytes: encodedValue)
+        XCTAssertEqual(value, decodedValue)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request adds the `BinaryParsableValue` protocol as a counterpart to `BinaryValueProtocol`. It also conforms `Foundation.Data` and `Foundation.UUID`.

### Design

There is only one initializer requirement, and its parameter name matches the `BinaryValueProtocol.bsonValueBytes` protocol requirement for clarity.

```swift
public protocol BinaryParsableValue: ParsableValue {
    init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8
}
``` 

### Implementation

Just like its encoding counterpart, this protocol reads BSON size metadata automatically and enforces size matching requirements.

```swift
extension BinaryParsableValue {
    public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
        guard data.count >= 5 else { throw ValueParseError.dataTooShort(5, data.count) }
        let declaredSize = Int(truncatingIfNeeded: try Int32(bsonBytes: data.prefix(4)))
        guard data.count == declaredSize + 5 else {
            throw ValueParseError.sizeMismatch(declaredSize + 5, data.count)
        }
        try self.init(bsonValueBytes: data.dropFirst(5))
    }
}
```
