### PR TITLE
 When a BSON value is also `Codable`, use its BSON representation 

### DIFF
--- a/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONKeyedEncodingContainer.swift
@@ -124,9 +124,15 @@ extension BSONKeyedEncodingContainer: KeyedEncodingContainerProtocol {
     }
 
     func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
-        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
-        try value.encode(to: encoder)
-        contents.append(key, encoder)
+        if let bsonValue = value as? ValueProtocol {
+            contents.append(key, ValueBox(bsonValue))
+            codingPath.append(key)
+        } else {
+            let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+            try value.encode(to: encoder)
+            contents.append(key, encoder)
+            codingPath.append(key)
+        }
     }
 
     func nestedContainer<NestedKey: CodingKey>(

--- a/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONSingleValueEncodingContainer.swift
@@ -125,9 +125,14 @@ extension BSONSingleValueEncodingContainer: SingleValueEncodingContainer {
     }
 
     func encode<T>(_ value: T) throws where T : Encodable {
-        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
-        try value.encode(to: encoder)
-        encodedValue = encoder.bsonBytes
-        encodedType = encoder.bsonType
+        if let bsonValue = value as? ValueProtocol {
+            encodedValue = bsonValue.bsonBytes
+            encodedType = bsonValue.bsonType
+        } else {
+            let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+            try value.encode(to: encoder)
+            encodedValue = encoder.bsonBytes
+            encodedType = encoder.bsonType
+        }
     }
 }

--- a/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
+++ b/Sources/BSONEncodable/BSONUnkeyedEncodingContainer.swift
@@ -105,9 +105,13 @@ extension BSONUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     }
 
     func encode<T: Encodable>(_ value: T) throws {
-        let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
-        try value.encode(to: encoder)
-        contents.append(encoder)
+        if let bsonValue = value as? ValueProtocol {
+            contents.append(ValueBox(bsonValue))
+        } else {
+            let encoder = BSONEncodingContainerProvider(codingPath: codingPath)
+            try value.encode(to: encoder)
+            contents.append(encoder)
+        }
     }
 
     func encode(_ value: Bool) throws {

--- a/Sources/BSONEncodable/ValueBox.swift
+++ b/Sources/BSONEncodable/ValueBox.swift
@@ -16,6 +16,11 @@ struct ValueBox {
     init<T: ValueProtocol>(_ value: T) {
         self.value = value
     }
+
+    /// Boxes the provided existential value.
+    init(_ value: ValueProtocol) {
+        self.value = value
+    }
 }
 
 extension ValueBox: ValueProtocol {

--- a/Tests/BSONDecodableTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONKeyedDecodingContainerTests.swift
@@ -250,6 +250,21 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         XCTAssertEqual(try container.decode(Int64?.self, forKey: .test), value)
     }
 
+    /// Asserts decoding a value that conforms to both `Decodable` and `ParsableValue` returns
+    /// the expected value even when it is encoded using its BSON representation.
+    /// 
+    /// This test uses `Foundation.Data`, which would normally be decoded as a nested
+    /// array document of `UInt64` values.
+    func testDecodeBSONValue() throws {
+        let value = Data([1, 2, 3, 4])
+        let doc = ComposedDocument {
+            "test" => value
+        }
+        let parsedDoc = try ParsedDocument(bsonBytes: doc.bsonBytes)
+        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        XCTAssertEqual(try container.decode(Data.self, forKey: .test), value)
+    }
+
     func testNestedContainer() throws {
         let value = "passed?"
         let doc = ComposedDocument {

--- a/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONSingleValueDecodingContainerTests.swift
@@ -176,11 +176,24 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         }
     }
 
-    // MARK: Optional
+    // MARK: Generic
 
     func testOptional() throws {
         let value: Int32? = .random(in: .min ... .max)
         let container = BSONSingleValueDecodingContainer(contents: value.bsonBytes, codingPath: [])
         XCTAssertEqual(try container.decode(Int32?.self), value)
+    }
+
+    /// Asserts decoding a value that conforms to both `Decodable` and `ParsableValue` returns
+    /// the expected value even when it is encoded using its BSON representation.
+    /// 
+    /// This test uses `Foundation.Data`, which would normally be decoded as a nested
+    /// array document of `UInt64` values.
+    func testDecodeBSONValue() throws {
+        let value = Data([1, 2, 3, 4])
+        let container = BSONSingleValueDecodingContainer<[UInt8]>(
+            contents: value.bsonBytes, 
+            codingPath: [])
+        XCTAssertEqual(try container.decode(Data.self), value)
     }
 }

--- a/Tests/BSONDecodableTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BSONDecodableTests/BSONUnkeyedDecodingContainerTests.swift
@@ -219,6 +219,20 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
         XCTAssertEqual(try container.decode(String?.self), value)
     }
 
+    /// Asserts decoding a value that conforms to both `Decodable` and `ParsableValue` returns
+    /// the expected value even when it is encoded using its BSON representation.
+    /// 
+    /// This test uses `Foundation.UUID`, which would normally be decoded as its `uuidString`.
+    func testDecodeBSONValue() throws {
+        let value = UUID()
+        let doc = ComposedDocument {
+            "0" => value
+        }
+        let parsedDoc = try ParsedDocument(bsonBytes: doc.bsonBytes)
+        var container = BSONUnkeyedDecodingContainer<[UInt8]>(doc: parsedDoc)
+        XCTAssertEqual(try container.decode(UUID.self), value)
+    }
+
     enum Key: CodingKey {
         case test
     }

--- a/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONKeyedEncodingContainerTests.swift
@@ -9,6 +9,7 @@
 import BSONEncodable
 import BSONCompose
 import XCTest
+import Foundation
 
 class BSONKeyedEncodingContainerTests: XCTestCase {
     enum Key: CodingKey {
@@ -100,6 +101,20 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
         }
         .bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    /// Asserts encoding a value that is both `Encodable` and conforms to `ValueProtocol` uses
+    /// its BSON representation instead of its `Encodable` representation.
+    /// 
+    /// This test uses `Foundation.UUID`, which is usually encoded as its `uuidString`.
+    func testEncodeBSONValue() throws {
+        let value = UUID()
+        let container = BSONKeyedEncodingContainer<Key>(codingPath: [])
+        try container.encode(value, forKey: .test)
+        let expectedDoc = ComposedDocument {
+            "test" => value
+        }
+        XCTAssertEqual(expectedDoc.bsonBytes, container.bsonBytes)
     }
 
     func testNestedKeyedContainer() throws {

--- a/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONSingleValueEncodingContainerTests.swift
@@ -9,6 +9,7 @@
 import BSONEncodable
 import BSONCompose
 import XCTest
+import Foundation
 
 class BSONSingleValueEncodingContainerTests: XCTestCase {
     func testEncodeDouble() throws {
@@ -158,5 +159,18 @@ class BSONSingleValueEncodingContainerTests: XCTestCase {
         XCTAssertEqual(container.bsonBytes, expectedBytes)
         let expectedType = value.bsonType
         XCTAssertEqual(container.bsonType, expectedType)
+    }
+
+    /// Asserts encoding a value that conforms to both `Encodable` and `ValueProtocol` uses its
+    /// BSON representation.
+    /// 
+    /// This test uses `Foundation.Data`, which would normally be encoded as a nested array
+    /// document of `UInt64` values.
+    func testEncodeBSONValue() throws {
+        let value = Data([1, 2, 3, 4])
+        let container = BSONSingleValueEncodingContainer(codingPath: [])
+        try container.encode(value)
+        XCTAssertEqual(container.bsonBytes, value.bsonBytes)
+        XCTAssertEqual(container.bsonType, value.bsonType)
     }
 }

--- a/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
+++ b/Tests/BSONEncodableTests/BSONUnkeyedEncodingContainerTests.swift
@@ -9,6 +9,7 @@
 import BSONEncodable
 import BSONCompose
 import XCTest
+import Foundation
 
 class BSONUnkeyedEncodingContainerTests: XCTestCase {
     enum Key: CodingKey {
@@ -101,6 +102,20 @@ class BSONUnkeyedEncodingContainerTests: XCTestCase {
         }
         .bsonBytes
         XCTAssertEqual(container.bsonBytes, expectedBytes)
+    }
+
+    /// Asserts encoding a value that conforms to both `Encodable` and `ValueProtocol` uses its 
+    /// BSON representation.
+    /// 
+    /// This test uses `Foundation.UUID` which is usually encoded as its `uuidString`.
+    func testEncodeBSONValue() throws {
+        let value = UUID()
+        let container = BSONUnkeyedEncodingContainer(codingPath: [])
+        try container.encode(value)
+        let expectedDoc = ComposedDocument {
+            "0" => value
+        }
+        XCTAssertEqual(expectedDoc.bsonBytes, container.bsonBytes)
     }
     
     func testNestedKeyedContainer() throws {


### PR DESCRIPTION
### Objectives

This pull request reinstates expected `ValueProtocol` and `ParsableValue` binary representations when conforming types are used with `BSONEncoder` and `BSONDecoder`. This closes #28.

### Design

Before this, these values are encoded and decoded according to their `Codable` representation, which may be unexpected. This brings documents composed and parsed with the `Codable` compatibility modules in line with `BSONCompose` and `BSONParse` themselves. The only caveot is custom BSON types must implement at least a dummy `Codable` conformance for this to work.

### Implementation

When the generic encode and decode methods are called on each container, we check whether the requested type is a BSON type. If so, it is force-upcasted to its existential type and encoded/initialized using its protocol conformance. For decoding, it is foce-downcasted back to its generic type and returned.

The snippet below is from `BSONKeyedDecodingContainer`:
```swift
if type is ParsableValue.Type {
    let decodedValue = try readExistential(
            (type as! ParsableValue.Type), 
            forKey: key, 
            as: type)
        codingPath.append(key)
        return decodedValue
    } else {
        let encodedValue = try valueData(forKey: key)
        let decoder = DecodingContainerProvider(encodedValue: encodedValue, codingPath: codingPath)
        let decodedValue = try type.init(from: decoder)
        codingPath.append(key)
        return decodedValue
    }
```