### PR TITLE
Conform `ObjectID` to `Codable`

### DIFF
--- a/Sources/BSONObjectID/ObjectID.swift
+++ b/Sources/BSONObjectID/ObjectID.swift
@@ -157,3 +157,22 @@ extension ObjectID: Hashable {
         withUnsafeBytes(of: self) { hasher.combine(bytes: $0) }
     }
 }
+
+extension ObjectID: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let hex = try container.decode(String.self)
+        guard let idFromHex = ObjectID(hex) else {
+            let context = DecodingError.Context(
+                codingPath: decoder.codingPath, 
+                debugDescription: "the decoded ID was not a valid hex ObjectID")
+            throw DecodingError.typeMismatch(ObjectID.self, context)
+        }
+        self = idFromHex
+    }
+}

--- a/Tests/BSONObjectIDTests/ObjectIDTests.swift
+++ b/Tests/BSONObjectIDTests/ObjectIDTests.swift
@@ -72,4 +72,15 @@ class ObjectIDTests: XCTestCase {
         id.incrementByOne()
         XCTAssertEqual(originalIncrement + 1, id.increment)
     }
+
+    /// Asserts encoding an `ObjectID` using a non-BSON `Encoder` 
+    /// encodes the appropriate hex string, and decoding it results in the same ID.
+    func testNonBSONEncoding() throws {
+        let id = ObjectID()
+        let encoder = JSONEncoder()
+        let encodedID = try encoder.encode(id)
+        let decoder = JSONDecoder()
+        let decodedID = try decoder.decode(ObjectID.self, from: encodedID)
+        XCTAssertEqual(id, decodedID)
+    }
 }


### PR DESCRIPTION
### Objectives

This pull request conforms `ObjectID` to `Codable`. This makes the type portable to non-BSON formats, and allows it to be used with `BSONEncoder` and `BSONDecoder`.

### Implementation

When used with external encoders, the ID's `description` is used, which is its hexadecimal string representation. 

When decoding, its `LosslessStringConvertible` intializer is used to decode the hex string. Since this is a failable initializer, the `DecodingError.typeMismatch` error is thrown in the event of a failure.