### PR TITLE
Support `Foundation.Date` as the BSON UTC DateTime type

### DIFF
--- a/Sources/BSONCompose/Values/Date+ValueProtocol.swift
+++ b/Sources/BSONCompose/Values/Date+ValueProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  Date+ValueProtocol.swift
+//
+//
+//  Created by Christopher Richez on May 26 2022
+//
+
+import Foundation
+
+extension Date: ValueProtocol {
+    public var bsonType: UInt8 { 9 }
+    public var bsonBytes: [UInt8] { 
+        let seconds = timeIntervalSince1970
+        let milliseconds = seconds * 1000
+        return Int64(milliseconds).bsonBytes
+    }
+}

--- a/Sources/BSONParse/Date+ParsableValue.swift
+++ b/Sources/BSONParse/Date+ParsableValue.swift
@@ -1,0 +1,14 @@
+//
+//  Date+ParsableValue.swift
+//
+//
+//  Created by Christopher Richez on May 26, 2022
+//
+
+import Foundation
+
+extension Date: ParsableValue {
+    public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
+        self = Date(timeIntervalSince1970: Double(try Int64(bsonBytes: data)) / 1000)
+    }
+}

--- a/Tests/BSONComposeTests/BinaryValueTests.swift
+++ b/Tests/BSONComposeTests/BinaryValueTests.swift
@@ -41,4 +41,10 @@ class BinaryValueTests: XCTestCase {
         ]
         XCTAssertEqual(doc.bsonBytes, expectedDoc)
     }
+
+    func testDate() {
+        let value = Date(timeIntervalSince1970: 3600.0).bsonBytes
+        let expectedValue = Int64(3_600_000).bsonBytes
+        XCTAssertEqual(value, expectedValue)
+    }
 }

--- a/Tests/BSONParseTests/ParsableValueTests.swift
+++ b/Tests/BSONParseTests/ParsableValueTests.swift
@@ -157,4 +157,16 @@ class ParsableValueTests: XCTestCase {
             XCTAssertEqual(have, faultyBytes.count)
         }
     }
+
+    // MARK: Date
+
+    func testDateParsed() throws {
+        let value = Date()
+        let decodedValue = try Date(bsonBytes: value.bsonBytes)
+        let minTolerated = value - 0.001
+        let maxTolerated = value + 0.001
+        // The BSON date is a millisecond-precision value, so allow for some error
+        XCTAssertTrue(decodedValue >= minTolerated) 
+        XCTAssertTrue(decodedValue <= maxTolerated)
+    }
 }


### PR DESCRIPTION
### Objectives

This pull request supports `Foundation.Date` by conforming it to `ValueProtocol` and `ParsableValue` under BSON type 9, "UTC DateTime." This closes #27.

### Design

`Date` is part of the recent addition of cross-platform `Foundation` types to the library. It works as expected on all Swift platforms, and already has a BSON analog.

The BSON DateTime type is a millisecond-precision integer, whereas `Date` can have as many decimals as `Double` allows. This means converting a `Date` to BSON and back is lossy.

We could also use the BSON Double type, which would make the API lossless. However if clients want perfect precision, it is very easy to encode a valid `Double` instead. The following snippet encodes and decodes both a Double and a UTC DateTime value:
```swift
let doc = ComposedDocument {
    "date" => Date()
    "double" => Date().timeIntervalSince1970
}

let parsedDoc = try ParsedDocument(bsonBytes: doc.bsonBytes)
let roughDate = try Date(bsonBytes: parsedDoc["date"])
let exactDate = try Date(timeIntervalSince1970: try Double(bsonBytes: doc["double"]))
```

### Implementation

The `ParsableValue` protocol initializer and the `ValueProtocol.bsonBytes` property delegate to the `Int64` implementation entirely.

For testing equality through encoding and decoding, we tolerate results within 1 millisecond of each other. This is technically more than the implementation should allow, but was selected for simplicity.