### PR TITLE
Refine documentation and support docc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Package.resolved
 
 Sources/BisonWrite/BisonWrite.docc/.docc-build
 Sources/BisonRead/BisonRead.docc/.docc-build
+Sources/BisonEncode/BisonEncode.docc/.docc-build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Sources/BisonWrite/BisonWrite.docc/.docc-build
 Sources/BisonRead/BisonRead.docc/.docc-build
 Sources/BisonEncode/BisonEncode.docc/.docc-build
 Sources/BisonDecode/BisonDecode.docc/.docc-build
+Sources/ObjectID/ObjectID.docc/.docc-build

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Package.resolved
 .vscode
 .swiftpm
 .build
-Sourcery-1.6.1
+
+Sources/BisonWrite/BisonWrite.docc/.docc-build

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Package.resolved
 .build
 
 Sources/BisonWrite/BisonWrite.docc/.docc-build
+Sources/BisonRead/BisonRead.docc/.docc-build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Package.resolved
 Sources/BisonWrite/BisonWrite.docc/.docc-build
 Sources/BisonRead/BisonRead.docc/.docc-build
 Sources/BisonEncode/BisonEncode.docc/.docc-build
+Sources/BisonDecode/BisonDecode.docc/.docc-build

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Bison
+# 🦬 Bison
 
 BSON (binary JSON) encoding and decoding in Swift.
 
 ## Overview
 
-The swift-bison package exposes four main modules:
-* `BisonRead` and `BisonWrite` for fast, flexible and type-safe document encoding and decoding.
-* `BisonEncode` and `BisonDecode` to adapt existing Swift `Codable` code already in your project.
+The swift-bison package features **two flavors** of BSON document management:
+* `BisonRead` & `BisonWrite`: custom APIs designed for flexibility and performance.
+* `BisonEncode` & `BisonDecode`: Swift `Codable` adapters to start working with BSON today.
 
 This project is tested in continuous integration on the following platforms:
 * macOS 11
@@ -16,18 +16,115 @@ This project is tested in continuous integration on the following platforms:
 * ubuntu 20.04
 * Windows Server 2022
 
-## Usage
+## Version
 
 You can import this package by adding the following line to your `Package.swift` dependencies:
 ```swift
 .package(url: "https://github.com/crichez/swift-bison", .upToNextMinor("0.0.1"))
 ```
 
-*Note:* versions before 1.0.0 are considered pre-release, and code-breaking changes may be 
+*Note:* versions before 1.0.0 are considered pre-release, and sources-breaking changes may be 
 introduced with a minor version bump. Once the project graduates to 1.0.0, regular semantic
 versioning rules will apply.
 
 ## Documentation
 
-This package is extensively documented using [docc](https://github.com/apple/swift-docc).
-You can find inline documentation on all source files.
+**This package is documented using [swift-docc](https://github.com/apple/swift-docc)**. You can 
+build the documentation for a specific module by following instructions at that repository,
+or read inline documentation for each source file. The following sections give a brief 
+introduction to the most common APIs of each module.
+
+### BisonWrite
+
+Import the `BisonWrite` module to compose and encode complex documents using a custom result 
+builder. The following example declares a simple BSON document with conditionals and nesting,
+then encodes it to an Array of bytes.
+
+```swift
+import BisonWrite
+
+let ownerDoc = WritableDoc {
+    "name" => "Bob Belcher"
+    if season8 {
+        "age" => Int64(46)
+    } else {
+        "age" => Int64(45)
+    }
+    "children" => WritableArray {
+        "Tina"
+        "Louise"
+        "Gene"
+    }
+}
+.encode(as: [UInt8].self)
+```
+
+### BisonRead
+
+Import the `BisonRead` module to parse and decode documents from raw bytes. The following example
+parses a document, then extracts select values.
+
+```swift
+import BisonRead
+
+do {
+    // Parse and validate the document.
+    let doc = try ReadableDoc(bsonBytes: ownerDoc)
+    // Get the "name" value and initialize it as a String.
+    guard let nameData = doc["name"] else { return }
+    let name = try String(bsonBytes: nameData)
+    // Get the "children" nested document and initialize each value.
+    guard let childrenData = doc["children"] else { return }
+    let childrenDoc = try ReadableDoc(bsonBytes: childrenData)
+    for childNameData in childrenDoc.values {
+        let childName = try String(bsonBytes: childNameData)
+    }
+} catch DocError<[UInt8]>.unknownType(let type, let key, let progress) {
+    // Handle document parsing errors.
+} catch ValueError.sizeMismatch {
+    // Handle value parsing errors.
+}
+```
+
+### BisonEncode & BisonDecode
+
+Import the `BisonEncode` & `BisonDecode` modules to use the `BSONEncoder` and `BSONDecoder` types.
+These expose a similar API to Foundation's JSON encoder and decoder, while still featuring support
+for custom BSON types through `BisonWrite` & `BisonRead` APIs.
+
+```swift
+import BisonEncode
+import BisonDecode
+import Foundation
+
+struct Owner: Codable {
+    let name: String
+    let age: Int64
+    let children: [String]
+}
+
+do {
+    let owner = Owner(name: "Bob Belcher", age: 46, children: ["Tina", "Louise", "Gene"])
+    let encodedOwnerDoc = try BSONEncoder<Data>().encode(owner)
+    let decodedOwner = try BSONDecoder().decode(Owner.self, from: encodedOwnerDoc)
+} catch DecodingError.typeMismatch(let requested, let context) {
+    // Handle traditional Swift EncodingErrors and DecodingErrors
+}
+```
+
+### ObjectID
+
+The `ObjectID` module includes a full-featured BSON ObjectID implementation.
+
+```swift
+import ObjectID
+
+// Initialize IDs randomly or from hexadecimal data.
+var randomID = ObjectID()
+// Use the timestamp property for chronological tracking.
+let created: Date = randomID.timestamp
+// Use the increment property for version tracking.
+let version: Int = randomID.increment
+// Easily output hexadecimal strings using custom LosslessStringConvertible conformance
+let hexID = String(describing: randomID)
+```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Bison
 
-Binary JSON encoding and decoding in Swift.
+BSON (binary JSON) encoding and decoding in Swift.
 
 ## Overview
 
-The Bison package exposes two main modules:
-* `Bison` for fast, flexible and type-safe document encoding and decoding.
-* `BSONCodable` to adapt existing Swift `Codable` code already in your project.
-
-Each of these modules is available for encoding or decoding only by importing:
-* `BisonWrite` & `BisonRead` as alternatives to the full `Bison`.
-* `BisonEncode` & `BisonDecode` as alternatives to the full `BisonCodable`.
+The swift-bison package exposes four main modules:
+* `BisonRead` and `BisonWrite` for fast, flexible and type-safe document encoding and decoding.
+* `BisonEncode` and `BisonDecode` to adapt existing Swift `Codable` code already in your project.
 
 This project is tested in continuous integration on the following platforms:
 * macOS 11
@@ -24,74 +20,14 @@ This project is tested in continuous integration on the following platforms:
 
 You can import this package by adding the following line to your `Package.swift` dependencies:
 ```swift
-.package(url: "https://github.com/crichez/swift-bson", .upToNextMinor("0.0.1"))
+.package(url: "https://github.com/crichez/swift-bison", .upToNextMinor("0.0.1"))
 ```
 
 *Note:* versions before 1.0.0 are considered pre-release, and code-breaking changes may be 
 introduced with a minor version bump. Once the project graduates to 1.0.0, regular semantic
 versioning rules will apply.
 
-### BisonWrite
+## Documentation
 
-When using `BisonWrite`, document structure is declared using a custom result builder.
-```swift
-import BisonWrite
-
-// Use the => operator to pair keys and values
-let doc = WritableDoc {
-    "one" => 1
-    "two" => 2.0
-    "three" => "3"
-    "doc" => WritableDoc { 
-        "flag" => true
-        "maybe?" => String?.none
-    }
-}
-
-// Encode the final document using your collection of choice.
-let encodedDoc = doc.encode(as: Data.self)
-```
-
-### BisonRead
-
-When using `BisonRead`, decoding is done in two steps:
-1. Validate the document's structure by intializing a `ReadableDoc`
-2. Decode individual values using their `init(bsonBytes:)` initializer
-
-```swift
-import BisonRead
-
-// Parse the keys and structure first
-let doc = try ReadableDoc(bsonBytes: encodedDoc)
-
-// Get values individually from the document
-let one = try Int(bsonBytes: doc["one"])
-let two = try Double(bsonBytes: doc["two"])
-let three = try String(bsonBytes: doc["three"])
-
-// Nested documents are treated as values
-let nestedDoc = try ReadableDoc(bsonBytes: doc["doc"])
-
-// And they expose their contents the same way
-let flag = try Bool(bsonBytes: nestedDoc["flag"])
-let maybe = try String?(bsonBytes: nestedDoc["maybe?"])
-```
-
-### BisonCodable
-
-`BisonCodable` is meant as a drop-in replacement for `PropertyListEncoder` or `JSONDecoder`,
-including error handling using Swift `EncodingError` and `DecodingError`.
-You can use the `BSONEncoder` and `BSONDecoder` types as analogs that produce BSON documents.
-
-```swift
-import BisonCodable
-
-struct Person: Codable {
-    let name: String
-    let age: Int
-}
-
-let person = Person(name: "Bob Belcher", age: 41)
-let encodedPerson = try BSONEncoder<Data>().encode(person)
-let decodedPerson = try BSONDecoder().decode(Person.self, from: encodedPerson)
-```
+This package is extensively documented using [docc](https://github.com/apple/swift-docc).
+You can find inline documentation on all source files.

--- a/Sources/BisonDecode/BisonDecode.docc/BisonDecode.md
+++ b/Sources/BisonDecode/BisonDecode.docc/BisonDecode.md
@@ -1,0 +1,9 @@
+# ``BisonDecode``
+
+Use `BSONDecoder` to read `Decodable` values from BSON documents.
+
+## Topics
+
+### Decoders
+
+- ``BSONDecoder``

--- a/Sources/BisonEncode/BSONEncoder.swift
+++ b/Sources/BisonEncode/BSONEncoder.swift
@@ -17,20 +17,21 @@
 
 import Foundation
 
-/// Use `BSONEncoder` to write `Encodable` values into fully-formed BSON documents.
+/// Use `BSONEncoder` to write BSON documents from `Encodable` values.
 /// 
 /// `BSONEncoder` is generic over its encoded document type: `Doc`.
 /// The only constraint on this type is it must be a `RangeReplaceableCollection` with an
-/// element type of `UInt8`. In most cases, you can simply initialize your encoder over
+/// element type of `UInt8`. In most cases, you can simply initialize your encoder
 /// over the `Data` type as follows.
 /// 
-///     import Foundation
-///     import BisonEncode
+/// ```swift
+/// import Foundation
+/// import BisonEncode
 ///     
-///     let encoder = BSONEncoder<Data>()
-///     let document = try encoder.encode(myEncodableInstance)
-///     try document.write(to: file)
-/// 
+/// let encoder = BSONEncoder<Data>()
+/// let document = try encoder.encode(myEncodableInstance)
+/// try document.write(to: file)
+/// ```
 public struct BSONEncoder<Doc: RangeReplaceableCollection> where Doc.Element == UInt8 {
     /// Initializes an encoder.
     public init() {}

--- a/Sources/BisonEncode/BisonEncode.docc/BisonEncode.md
+++ b/Sources/BisonEncode/BisonEncode.docc/BisonEncode.md
@@ -1,0 +1,9 @@
+# ``BisonEncode``
+
+Encode BSON documents using Swift Codable.
+
+## Topics
+
+### Encoders
+
+- ``BSONEncoder``

--- a/Sources/BisonRead/BisonRead.docc/BisonRead.md
+++ b/Sources/BisonRead/BisonRead.docc/BisonRead.md
@@ -1,0 +1,18 @@
+# ``BisonRead``
+
+Read BSON documents.
+
+## Topics
+
+### Documents
+
+- ``ReadableDoc``
+
+### Values
+
+- ``ReadableValue``
+- ``CustomReadableValue``
+
+### Errors
+
+- ``BisonError``

--- a/Sources/BisonRead/BisonRead.docc/BisonRead.md
+++ b/Sources/BisonRead/BisonRead.docc/BisonRead.md
@@ -7,12 +7,12 @@ Read BSON documents.
 ### Documents
 
 - ``ReadableDoc``
+- ``DocError``
+- ``Progress``
 
 ### Values
 
 - ``ReadableValue``
 - ``CustomReadableValue``
+- ``ValueError``
 
-### Errors
-
-- ``BisonError``

--- a/Sources/BisonRead/BisonRead.docc/ReadableDoc.md
+++ b/Sources/BisonRead/BisonRead.docc/ReadableDoc.md
@@ -11,8 +11,8 @@ A BSON document from which values can be read.
 ### Parsing a Document
 
 - ``BisonRead/ReadableDoc/init(bsonBytes:)``
-- ``BisonRead/ReadableDoc/Error``
-- ``BisonRead/ReadableDoc/Progress``
+- ``BisonRead/DocError``
+- ``BisonRead/Progress``
 
 ### Extracting Values
 

--- a/Sources/BisonRead/BisonRead.docc/ReadableDoc.md
+++ b/Sources/BisonRead/BisonRead.docc/ReadableDoc.md
@@ -1,0 +1,24 @@
+# ``BisonRead/ReadableDoc``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: override)
+}
+
+A BSON document from which values can be read.
+
+## Topics
+
+### Parsing a Document
+
+- ``BisonRead/ReadableDoc/init(bsonBytes:)``
+- ``BisonRead/ReadableDoc/Error``
+- ``BisonRead/ReadableDoc/Progress``
+
+### Extracting Values
+
+- ``BisonRead/ReadableDoc/subscript(_:)``
+- ``BisonRead/ReadableDoc/keys``
+- ``BisonRead/ReadableDoc/values``
+- ``BisonRead/ReadableDoc/min``
+- ``BisonRead/ReadableDoc/max``
+

--- a/Sources/BisonRead/CustomReadableValue.swift
+++ b/Sources/BisonRead/CustomReadableValue.swift
@@ -15,9 +15,30 @@
 //  limitations under the License.
 //
 
-/// A BSON value whose encoded form declares the BSON binary type (5).
+/// A protocol that defines how a custom value is read from a document.
 ///
-/// Conform to `CustomReadableValue` for BSON binary values to inherit metadata parsing.
+/// ## Conforming to CustomReadableValue
+/// 
+/// Conform to this protocol to decode a custom value from its raw BSON representation. The value's
+/// raw bytes are passed to the ``init(bsonValueBytes:)`` initializer as a generic `Collection`.
+/// The following example is the actual `UUID` conformance.
+/// 
+/// ```swift
+/// extension UUID: CustomReadableValue {
+///     public init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8 {
+///         guard bsonValueBytes.count == 16 else {    
+///             throw BisonError.sizeMismatch(16, bsonValueBytes.count)
+///         }
+///         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(capacity: 16, alignment: 16)
+///         copyBuffer.copyBytes(from: bsonValueBytes)
+///         self = copyBuffer.load(as: UUID.self)
+///     }
+/// }
+/// ```
+/// 
+/// > Note: BSON "binary" types include size and type metadata. These are usually parsed for you,
+///   so the data in `bsonValueBytes` is always the declared size. This may not be the size
+///   you expect due to encoding errors, so you should always check.
 public protocol CustomReadableValue: ReadableValue {
     /// Initializes a value from the provided BSON data.
     ///

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -66,7 +66,7 @@ public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
     ///   this error may be triggered instead.
     case docSizeMismatch(expectedExactly: Int)
 
-    /// An unknown or deprecated BSON type byte was found while parsing a key.
+    /// An unknown BSON type byte was found while parsing a key.
     /// 
     /// This error includes a ``Progress`` value. You may check the partially decoded document
     /// within to recover from the error.

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -62,7 +62,7 @@ public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
     /// the data was corrupted in transit or isn't a valid BSON document.
     /// 
     /// > Note: In the case of corruption, ``notTerminated`` will usually be triggered first.
-    ///   There is a chance that the corrupted data happens to be null-terminated, in whcih case
+    ///   There is a chance that the corrupted data happens to be null-terminated, in which case
     ///   this error may be triggered instead.
     case docSizeMismatch(expectedExactly: Int)
 

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -62,7 +62,7 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// }       
     /// ```
     /// 
-    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
+    /// > Tip: For error handling documentation, see ``DocError`` and ``ValueError``.
     public subscript(key: String) -> Data.SubSequence? {
         discovered[key]
     }
@@ -91,7 +91,7 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// }
     /// ```
     /// 
-    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
+    /// > Tip: For error handling documentation, see ``DocError`` and ``ValueError``.
     public var min: Data.SubSequence? {
         guard let minKey = minKey, let min = discovered[minKey] else { return nil }
         return min
@@ -121,7 +121,7 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// }
     /// ```
     /// 
-    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
+    /// > Tip: For error handling documentation, see ``DocError`` and ``ValueError``.
     public var max: Data.SubSequence? {
         guard let maxKey = maxKey, let max = discovered[maxKey] else { return nil }
         return max

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -19,22 +19,50 @@ import OrderedCollections
 
 // MARK: Public API & Storage
 
-/// A document where keys and values have been discovered and can be retrieved.
+// See Sources/BisonRead/BisonRead.docc/ReadableDoc.md
 public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// The keys and discovered values in this document.
     let discovered: OrderedDictionary<String, Data.SubSequence>
 
-    /// The keys discovered in this document.
+    /// The keys discovered in this document, in the order they were discovered.
+    /// 
+    /// - Complexity: O(1).
     public var keys: OrderedSet<String> {
         discovered.keys
     }
 
-    /// The value blocks discovered in this document.
+    /// The BSON bytes of each value discovered in this document, 
+    /// in the order they were discovered.
+    /// 
+    /// - Complexity: O(1).
     public var values: OrderedDictionary<String, Data.SubSequence>.Values {
         discovered.values
     }
 
-    /// Returns the value data block for the specified key, or `nil` if the key doesn't exist.
+    /// Returns the BSON value data associated with the specified key, or `nil` if the key doesn't
+    /// exist.
+    /// 
+    /// The data returned is a sub-sequence of the original collection passed to the initializer.
+    /// It is the caller's responsibility to know the type of data associated with each key.
+    /// 
+    /// The following example extracts a `String` value assigned to the "name" key.
+    /// 
+    /// ```swift
+    /// do {
+    ///     // Start with a buffer of type Data    
+    ///     let encodedDoc: Data  = ...     
+    ///     // Parse the document   
+    ///     let doc = try ReadableDoc(bsonBytes: encodedDoc)
+    ///     // Unwrap the value's data
+    ///     guard let nameData = doc["name"] else { return }
+    ///     // Initialize the value
+    ///     let name = try String(bsonBytes: nameData)
+    /// } catch {
+    ///     // Handle document and value initializer errors
+    /// }       
+    /// ```
+    /// 
+    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
     public subscript(key: String) -> Data.SubSequence? {
         discovered[key]
     }
@@ -42,7 +70,28 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// The declared minimum key for this document.
     let minKey: String?
 
-    /// The minimum value declared by this document, or `nil` if none was declared.
+    /// The BSON bytes of the minimum value declared by this document, or `nil` if none was 
+    /// declared.
+    /// 
+    /// It is the caller's responsibility to know the type of the minimum value.
+    /// The following example extracts the minimum value as a `Double`.
+    /// 
+    /// ```swift
+    /// do {
+    ///     // Start with a buffer of type Data    
+    ///     let encodedDoc: Data  = ...     
+    ///     // Parse the document   
+    ///     let doc = try ReadableDoc(bsonBytes: encodedDoc)
+    ///     // Unwrap the value's data
+    ///     guard let minData = doc.min else { return }
+    ///     // Initialize the value
+    ///     let minValue = try Double(bsonBytes: minData)
+    /// } catch {   
+    ///     // Handle document and value initializer errors
+    /// }
+    /// ```
+    /// 
+    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
     public var min: Data.SubSequence? {
         guard let minKey = minKey, let min = discovered[minKey] else { return nil }
         return min
@@ -51,7 +100,28 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
     /// The declared maximum key for this document.
     let maxKey: String?
 
-    /// The maximum value declared by this document, or `nil` if none was declared.
+    /// The BSON bytes of the maximum value declared by this document, or `nil` if none was 
+    /// declared.
+    /// 
+    /// It is the caller's responsibility to know the type of the maximum value.
+    /// The following example extracts the maximum value as a `Double`.
+    /// 
+    /// ```swift
+    /// do {
+    ///     // Start with a buffer of type Data    
+    ///     let encodedDoc: Data  = ...     
+    ///     // Parse the document   
+    ///     let doc = try ReadableDoc(bsonBytes: encodedDoc)
+    ///     // Unwrap the value's data
+    ///     guard let maxData = doc.max else { return }
+    ///     // Initialize the value
+    ///     let maxValue = try Double(bsonBytes: maxData)
+    /// } catch {   
+    ///     // Handle document and value initializer errors
+    /// }
+    /// ```
+    /// 
+    /// > Tip: For error handling documentation, see ``Error`` and ``BisonError``.
     public var max: Data.SubSequence? {
         guard let maxKey = maxKey, let max = discovered[maxKey] else { return nil }
         return max
@@ -74,7 +144,7 @@ public struct ReadableDoc<Data: Collection> where Data.Element == UInt8 {
 // MARK: Errors
 
 extension ReadableDoc {
-    /// An error that occured while parsing this BSON document during initialization.
+    /// An error that occured while initializing a BSON document from raw data.
     public enum Error: Swift.Error {
         /// Less than 5 bytes were passed to the initializer.
         /// 

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -15,14 +15,43 @@
 //  limitations under the License.
 //
 
-/// A value that can be parsed from its encoded BSON representation.
+/// A protocol that defines how a BSON value is read from a document.
+/// 
+/// ## Conforming to ReadableValue
+/// 
+/// ``BisonWrite`` supports external types in two cases:
+/// 1. **Custom types** that do not exist in the specification.
+/// 2. **Alternatives** to specification types built into the framework.
+/// 
+/// ### Custom Types
+/// 
+/// To decode a type that does not exist in the specification, ``CustomReadableValue`` provides
+/// default implementations that make conforming to ``ReadableValue`` much simpler. In most cases,
+/// That is the recommended protocol to conform to. 
+/// 
+/// ### Alternative Types
+/// 
+/// To decode an alternative version of a specification type, conform to this protocol directly.
+/// You only need to provide a way to initialize a value from its encoded BSON bytes. These are
+/// provided to you as a `Collection` in the ``init(bsonBytes:)`` method. The following example
+/// copies the data for a `Double` into a raw buffer and loads it using Swift's manual memory
+/// management APIs.
+/// 
+/// ```swift
+/// extension Double: ReadableValue {
+///     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
+///         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
+///         copyBuffer.copyBytes(from: data)
+///         self = copyBuffer.load(as: Double.self)
+///     }
+/// } 
+/// ```
 public protocol ReadableValue {
-    /// Initializes this value from the provided BSON bytes.
+    /// Initializes this value from its encoded BSON representation.
     /// 
-    /// - Parameter data: the encoded value, usually returned by the `ReadableDoc` subscript
+    /// - Parameter data: a collection of bytes containing the value's encoded BSON representation
     /// 
-    /// - Throws:
-    /// A `BisonError` appropriate for the type to initialize.
+    /// - Throws: A ``BisonError`` that describes the failure.
     init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8
 }
 

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -40,6 +40,7 @@
 /// ```swift
 /// extension Double: ReadableValue {
 ///     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
+///         guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
 ///         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
 ///         copyBuffer.copyBytes(from: data)
 ///         self = copyBuffer.load(as: Double.self)

--- a/Sources/BisonRead/ValueError.swift
+++ b/Sources/BisonRead/ValueError.swift
@@ -19,11 +19,13 @@
 public enum ValueError: Error, Equatable {
     /// The data passed to the initializer was shorter than the required metadata for this value.
     /// 
+    /// This usually means the value was not the type you expected.
     /// This case provides the expected and actual size of the data passed to the initializer.
     case dataTooShort(_ needAtLeast: Int, _ found: Int)
 
     /// The data passed to the initializer was not the expected size for this type.
     /// 
+    /// This usually means the value was not the type you expected.
     /// This case provides the expected and actual size of the data passed to the initializer.
     case sizeMismatch(_ expected: Int, _ have: Int)
 }

--- a/Sources/BisonWrite/ArrayDocBuilder.swift
+++ b/Sources/BisonWrite/ArrayDocBuilder.swift
@@ -17,6 +17,11 @@ extension Array: DocComponent where Element == WritableValue {
     }
 }
 
+/// A result builder used to declare the structure of an integer-keyed BSON document.
+/// 
+/// > Note: You won't usually interact with the `ArrayDocBuilder` type directly. You do so 
+///   implicitly when initializing a ``WritableArray``. See that documentation for more details.
+/// 
 @resultBuilder public struct ArrayDocBuilder {
     public static func buildExpression(_ expression: WritableValue) -> Array<WritableValue> {
         [expression]

--- a/Sources/BisonWrite/BisonWrite.docc/BisonWrite.md
+++ b/Sources/BisonWrite/BisonWrite.docc/BisonWrite.md
@@ -1,0 +1,28 @@
+
+# ``BisonWrite``
+
+Compose BSON documents for writing.
+
+## Topics
+
+### BSON Documents
+
+- ``WritableDoc``
+- ``DocBuilder``
+
+### BSON Document Components
+
+- ``DocComponent``
+- ``ForEach``
+- ``Group``
+- ``Pair``
+
+### BSON Arrays
+
+- ``WritableArray``
+- ``ArrayDocBuilder``
+
+### BSON Values
+
+- ``WritableValue``
+- ``CustomWritableValue``

--- a/Sources/BisonWrite/BisonWrite.docc/BisonWrite.md
+++ b/Sources/BisonWrite/BisonWrite.docc/BisonWrite.md
@@ -10,13 +10,6 @@ Compose BSON documents for writing.
 - ``WritableDoc``
 - ``DocBuilder``
 
-### BSON Document Components
-
-- ``DocComponent``
-- ``ForEach``
-- ``Group``
-- ``Pair``
-
 ### BSON Arrays
 
 - ``WritableArray``
@@ -26,3 +19,10 @@ Compose BSON documents for writing.
 
 - ``WritableValue``
 - ``CustomWritableValue``
+
+### BSON Document Components
+
+- ``DocComponent``
+- ``ForEach``
+- ``Group``
+- ``Pair``

--- a/Sources/BisonWrite/Components/DocComponent.swift
+++ b/Sources/BisonWrite/Components/DocComponent.swift
@@ -16,8 +16,11 @@
 //
 
 /// A basic building block of a BSON document.
+/// 
+/// `DocComponent` is used as the return type of all ``DocBuilder`` declarations. You shouldn't
+/// need to conform anything to this protocol.
 public protocol DocComponent {
-    /// Appends this components BSON bytes to the end of a document.
+    /// Appends this component's BSON bytes to the end of a document.
     func append<Doc>(to document: inout Doc)
     where Doc : RangeReplaceableCollection, Doc.Element == UInt8
 }

--- a/Sources/BisonWrite/Components/ForEach.swift
+++ b/Sources/BisonWrite/Components/ForEach.swift
@@ -15,7 +15,9 @@
 //  limitations under the License.
 //
 
-/// Encodes a sequence into a document using the provided closure.
+/// Declares a component of a BSON document from the contents of a `Sequence`.
+/// 
+/// Use ``init(_:transform:)`` to quickly convert any sequence to a series of key-value pairs.
 public struct ForEach<Base: Sequence, Element: DocComponent>: DocComponent {
     /// The transformed elements of this loop.
     let elements: LazyMapSequence<Base, Element>
@@ -29,9 +31,12 @@ public struct ForEach<Base: Sequence, Element: DocComponent>: DocComponent {
     /// }
     /// ```
     /// 
+    /// > Note: The closure can return anything conforming to ``DocComponent``. This includes
+    ///   ``Pair``, ``Group``, or another ``ForEach`` declaration. 
+    /// 
     /// - Parameters:
-    ///   - base: a `Sequence` of arbitrary type to which to return a document component
-    ///   - transform: a closure that takes a `base` element and returns a document component.
+    ///   - base: a `Sequence` of arbitrary type to use as input
+    ///   - transform: a closure that takes a `base` element and returns a ``DocComponent``
     public init(_ base: Base, @DocBuilder transform: @escaping (Base.Element) -> Element) {
         self.elements = base.lazy.map(transform)
     }

--- a/Sources/BisonWrite/Components/Group.swift
+++ b/Sources/BisonWrite/Components/Group.swift
@@ -15,7 +15,7 @@
 //  limitations under the License.
 //
 
-/// A group of document components values.
+/// A group of document components.
 /// 
 /// Use a `Group` when you need to declare more than 10 components in a document.
 /// Grouping document components does not affect the structure of the final document.

--- a/Sources/BisonWrite/Components/Pair.swift
+++ b/Sources/BisonWrite/Components/Pair.swift
@@ -17,7 +17,7 @@
 
 /// A key-value pair used to compose a BSON document.
 /// 
-/// To create a `Pair`, use the `=>` operator on a `String` and a `WritableValue` conforming value:
+/// To create a `Pair`, use the `=>` operator on a `String` and a `WritableValue`.
 /// ```swift
 /// let doc = WritableDoc {
 ///     "key" => "value"

--- a/Sources/BisonWrite/DocBuilder.swift
+++ b/Sources/BisonWrite/DocBuilder.swift
@@ -15,8 +15,12 @@
 //  limitations under the License.
 //
 
-@resultBuilder
-public struct DocBuilder {
+/// A result builder used to declare the structure of a string-keyed BSON document.
+/// 
+/// > Note: You won't usually interact with the `DocBuilder` type directly. You do so implicitly 
+///   when initializing a ``WritableDoc``. See that documentation for more details.
+/// 
+@resultBuilder public struct DocBuilder {
     public static func buildBlock<T: DocComponent>(_ t: T) -> some DocComponent {
         t
     }

--- a/Sources/BisonWrite/Values/WritableValue.swift
+++ b/Sources/BisonWrite/Values/WritableValue.swift
@@ -40,6 +40,8 @@
 /// ### Custom
 /// 
 /// * ``ObjectID``
+/// * ``WritableDoc``
+/// * ``WritableArray``
 /// 
 /// ## Conforming to `WritableValue`
 /// 

--- a/Sources/BisonWrite/Values/WritableValue.swift
+++ b/Sources/BisonWrite/Values/WritableValue.swift
@@ -17,6 +17,30 @@
 
 /// A protocol that defines how a BSON value is written to a document.
 /// 
+/// ## Built-In Types
+/// 
+/// The following types conform to `WritableValue`.
+/// 
+/// ### Standard Library
+/// 
+/// * `Double`
+/// * `String`
+/// * `Bool`
+/// * `Int32`
+/// * `Int64`
+/// * `UInt64`
+/// * `Optional` where `Wrapped` also conforms
+/// 
+/// ### Foundation
+/// 
+/// * `Date`
+/// * `Data`
+/// * `UUID`
+/// 
+/// ### Custom
+/// 
+/// * ``ObjectID``
+/// 
 /// ## Conforming to `WritableValue`
 /// 
 /// The framework can be extended to support alternative versions of built-in BSON types,

--- a/Sources/BisonWrite/Values/WritableValue.swift
+++ b/Sources/BisonWrite/Values/WritableValue.swift
@@ -15,11 +15,61 @@
 //  limitations under the License.
 //
 
-/// A value that can be assigned to a ``Pair`` in a BSON document.
+/// A protocol that defines how a BSON value is written to a document.
+/// 
+/// ## Conforming to `WritableValue`
+/// 
+/// The framework can be extended to support alternative versions of built-in BSON types,
+/// or custom types. 
+/// 
+/// ### Custom Non-Specification Types
+/// 
+/// The specification supports encoding custom user-defined types as "binary" types. 
+/// ``BisonWrite`` provides a convenience protocol for this use case called
+/// ``CustomWritableValue``. In most cases, conforming through that protocol is recommended.
+/// 
+/// ### Replacements to Specification Types
+/// 
+/// If you prefer to use your own type instead of a built-in one for a specification type,
+/// you should conform that type to this protocol. A good example would be using a custom date 
+/// type as an alternative to `Foundation.Date`. 
+/// 
+/// BSON values must declare a type byte (or type number) to inform decoder implementations of the
+/// value assigned to each key. You can find the byte to declare for your type in 
+/// [the specification](https://bsonspec.org/spec.html), then declare it using the ``bsonType``
+/// property.
+/// 
+/// ```swift
+/// extension Double: ValueProtocol {
+///     public var bsonType: UInt8 { 1 }
+///     ...
+/// }
+/// ```
+///
+/// The ``append(to:)`` method appends the value's data to the document. The document conforms
+/// to `RangeReplaceableCollection` and can generally be thought of as an `Array` or `Data` buffer.
+/// 
+/// ```swift
+/// extension Double: ValueProtocol {
+///     ...
+///     public func append<Doc>(to document: inout Doc)
+///     where Doc : RangeReplaceableCollection, Doc.Element == UInt8 {
+///         withUnsafeBytes(of: self.bitPattern) { bytes in 
+///             document.append(contentsOf: bytes)
+///         }    
+///     }
+/// }
+/// ```
+/// 
+/// > Tip: The `Index` type of the document is unconstrained, which can make mutations other
+///   than `append(_:)` and `append(contentsOf:)` more challenging. You can calculate indices
+///   using `Collection` methods and replace entire ranges using the document's
+///   `replaceSubrange(_:with:)` method.
+/// 
 public protocol WritableValue {
-    /// The BSON type byte for this type.
+    /// The type byte to assign to keys that declare this value.
     /// 
-    /// This is the number that will be prefixed to keys that declare this value type.
+    /// Type bytes are defined in [the BSON specification](https://bsonspec.org/spec.html).
     var bsonType: UInt8 { get }
     
     /// Appends this value to the end of a BSON document.

--- a/Sources/ObjectID/ObjectID.docc/ObjectID.md
+++ b/Sources/ObjectID/ObjectID.docc/ObjectID.md
@@ -1,0 +1,3 @@
+# ``ObjectID``
+
+A BSON native unique identifier type that features a timestamp and change tracking.


### PR DESCRIPTION
## Objectives

This pull request refines and expands the documentation for all modules, and includes docc catalogs to support compiler-generated documentation archives.

## Detailed Design

Each module has a single landing page that categorizes symbols where appropriate. All other documentation is inline to make it more discoverable to non-docc clients. The framework is simple enough that I opted not to include tutorials, but these can be added on request.
